### PR TITLE
fix: escaped identifiers, unaliased projections, procedural BFS guardrails

### DIFF
--- a/src/gsql2rsql/parser/visitor.py
+++ b/src/gsql2rsql/parser/visitor.py
@@ -50,6 +50,91 @@ from gsql2rsql.parser.operators import (
 )
 
 
+def unescape_symbolic_name(name: str) -> str:
+    """Strip backtick delimiters from an openCypher EscapedSymbolicName.
+
+    openCypher allows any identifier — label, relationship type, variable,
+    property key — to be escaped with backticks so it may contain characters
+    that are otherwise illegal::
+
+        MATCH (n:`My Label`) RETURN n.`first name`
+
+    The backticks are delimiters, not part of the name, so ``:`Person``` and
+    ``:Person`` must both bind to the node type ``Person``.  A doubled
+    backtick inside the escape is the literal escape for one backtick.
+
+    Non-escaped names are returned unchanged.
+    """
+    if len(name) >= 2 and name.startswith("`") and name.endswith("`"):
+        return name[1:-1].replace("``", "`")
+    return name
+
+
+def split_escaped_labels(labels_text: str) -> list[str]:
+    """Split a label/type list on ``:`` respecting backtick escapes.
+
+    ``oC_NodeLabels``/``oC_RelationshipTypes`` arrive as raw text such as
+    ``":Person:Employee"`` or ``":`My Label`:Other"``.  A naive
+    ``lstrip(':')`` + ``split(':')`` corrupts escaped names that contain a
+    colon (``:`a:b``` would become ``a``), so the separator is only honoured
+    outside backticks.
+
+    Returns the unescaped names in order, with empty segments dropped.
+    """
+    names: list[str] = []
+    current: list[str] = []
+    in_backticks = False
+
+    for char in labels_text:
+        if char == "`":
+            in_backticks = not in_backticks
+            current.append(char)
+        elif char == ":" and not in_backticks:
+            if current:
+                names.append("".join(current))
+                current = []
+        else:
+            current.append(char)
+
+    if current:
+        names.append("".join(current))
+
+    return [unescape_symbolic_name(n) for n in names]
+
+
+def sanitize_expression_alias(expression_text: str) -> str:
+    """Derive a bare SQL identifier from raw Cypher expression text.
+
+    openCypher names an unaliased projection after the expression itself, so
+    ``RETURN count(DISTINCT d)`` yields a column called ``count(DISTINCT d)``.
+    That name is not a legal bare SQL identifier, and the renderer emits
+    aliases unquoted, so the punctuation is folded to underscores:
+
+        ``count(DISTINCT d)``  -> ``count_DISTINCT_d``
+        ``n.age + 1``          -> ``n_age_1``
+        ``count(*)``           -> ``count_star``
+
+    Returns an empty string if nothing usable survives, letting the caller
+    fall back to its own default rather than emitting a broken alias.
+    """
+    if not expression_text:
+        return ""
+
+    # '*' carries meaning (count(*) vs count(x)) so name it rather than drop it
+    text = expression_text.replace("*", "_star_")
+
+    sanitized = "".join(
+        char if char.isalnum() or char == "_" else "_" for char in text
+    )
+    sanitized = "_".join(part for part in sanitized.split("_") if part)
+
+    # A leading digit is not a legal identifier start (e.g. `RETURN 42`)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = f"_{sanitized}"
+
+    return sanitized
+
+
 class CypherVisitor:
     """
     Visitor that converts ANTLR parse tree to openCypher AST.
@@ -351,7 +436,7 @@ class CypherVisitor:
         list_expression = self.visit(ctx.oC_Expression())
 
         # Get the variable name
-        variable_name = ctx.oC_Variable().getText()
+        variable_name = unescape_symbolic_name(ctx.oC_Variable().getText())
 
         return UnwindClause(
             list_expression=list_expression,
@@ -375,7 +460,9 @@ class CypherVisitor:
             for part_ctx in ctx.oC_Pattern().oC_PatternPart() or []:
                 # Check for path variable assignment: path = (a)-[]->(b)
                 if part_ctx.oC_Variable():
-                    path_variable = part_ctx.oC_Variable().getText()
+                    path_variable = unescape_symbolic_name(
+                        part_ctx.oC_Variable().getText()
+                    )
 
                 # Get the pattern elements
                 if part_ctx.oC_AnonymousPatternPart():
@@ -463,15 +550,14 @@ class CypherVisitor:
         inline_properties = None
 
         if ctx.oC_Variable():
-            alias = ctx.oC_Variable().getText()
+            alias = unescape_symbolic_name(ctx.oC_Variable().getText())
 
         if ctx.oC_NodeLabels():
             labels = ctx.oC_NodeLabels().getText()
-            # Remove leading colon
-            entity_name = labels.lstrip(":")
-            # Take first label if multiple
-            if ":" in entity_name:
-                entity_name = entity_name.split(":")[0]
+            # Backtick-aware split; take first label if multiple
+            parsed_labels = split_escaped_labels(labels)
+            if parsed_labels:
+                entity_name = parsed_labels[0]
 
         # NEW: Extract inline properties if present
         if ctx.oC_Properties():
@@ -547,10 +633,16 @@ class CypherVisitor:
 
         if detail_ctx:
             if detail_ctx.oC_Variable():
-                alias = detail_ctx.oC_Variable().getText()
+                alias = unescape_symbolic_name(detail_ctx.oC_Variable().getText())
             if detail_ctx.oC_RelationshipTypes():
                 types_text = detail_ctx.oC_RelationshipTypes().getText()
-                entity_name = types_text.lstrip(":")
+                # Multi-type OR syntax (:A|B|:C) is kept joined by '|' — the
+                # planner splits it — but each type is unescaped individually.
+                entity_name = "|".join(
+                    name
+                    for part in types_text.split("|")
+                    for name in split_escaped_labels(part)
+                )
 
             # Extract variable-length path information (e.g., *1..5)
             if detail_ctx.oC_RangeLiteral():
@@ -711,9 +803,15 @@ class CypherVisitor:
 
         alias = None
         if ctx.oC_Variable():
-            alias = ctx.oC_Variable().getText()
+            alias = unescape_symbolic_name(ctx.oC_Variable().getText())
         elif isinstance(expr, QueryExpressionProperty):
             alias = expr.property_name or expr.variable_name
+        else:
+            # No explicit AS and not a property access (e.g. `RETURN count(*)`).
+            # openCypher names such a column after the expression text; an
+            # empty alias would emit `SELECT COUNT(*) AS  FROM ...`, which is a
+            # SQL syntax error surfacing only at execution time.
+            alias = sanitize_expression_alias(ctx.oC_Expression().getText())
 
         return QueryExpressionWithAlias(inner_expression=expr, alias=alias or "")
 
@@ -738,7 +836,7 @@ class CypherVisitor:
         # Get alias if present
         alias = ""
         if ctx.oC_Variable():
-            alias = ctx.oC_Variable().getText()
+            alias = unescape_symbolic_name(ctx.oC_Variable().getText())
         elif isinstance(expr, QueryExpressionProperty):
             alias = expr.property_name or expr.variable_name
         else:
@@ -1052,7 +1150,7 @@ class CypherVisitor:
     def visit_oC_PropertyLookup(self, ctx: Any) -> str | None:
         """Visit a property lookup context."""
         if ctx.oC_PropertyKeyName():
-            return ctx.oC_PropertyKeyName().getText()
+            return unescape_symbolic_name(ctx.oC_PropertyKeyName().getText())
         return None
 
     def visit_oC_StringListNullOperatorExpression(
@@ -1086,7 +1184,9 @@ class CypherVisitor:
 
         # Handle property lookups
         for lookup_ctx in ctx.oC_PropertyLookup() or []:
-            prop_name = lookup_ctx.oC_PropertyKeyName().getText()
+            prop_name = unescape_symbolic_name(
+                lookup_ctx.oC_PropertyKeyName().getText()
+            )
             if isinstance(result, QueryExpressionProperty):
                 result.property_name = prop_name
             elif isinstance(result, QueryExpression):
@@ -1126,7 +1226,9 @@ class CypherVisitor:
         if ctx.oC_Parameter():
             return self.visit(ctx.oC_Parameter())
         if ctx.oC_Variable():
-            return QueryExpressionProperty(variable_name=ctx.oC_Variable().getText())
+            return QueryExpressionProperty(
+                variable_name=unescape_symbolic_name(ctx.oC_Variable().getText())
+            )
         if ctx.oC_FunctionInvocation():
             return self.visit(ctx.oC_FunctionInvocation())
         if ctx.oC_ParenthesizedExpression():
@@ -1220,7 +1322,7 @@ class CypherVisitor:
 
         # Pair them up
         for key_ctx, expr_ctx in zip(key_ctxs, expr_ctxs):
-            key_name = key_ctx.getText()
+            key_name = unescape_symbolic_name(key_ctx.getText())
             value_expr = self.visit(expr_ctx)
             if isinstance(value_expr, QueryExpression):
                 entries.append((key_name, value_expr))
@@ -1582,7 +1684,7 @@ class CypherVisitor:
             raise TranspilerSyntaxErrorException(
                 "REDUCE requires an accumulator variable"
             )
-        accumulator_name = acc_var_ctx.getText()
+        accumulator_name = unescape_symbolic_name(acc_var_ctx.getText())
 
         # Get all expressions - there are 2 in the main rule:
         # 1. Initial value (after =)

--- a/src/gsql2rsql/planner/operators/data_source.py
+++ b/src/gsql2rsql/planner/operators/data_source.py
@@ -22,6 +22,51 @@ from gsql2rsql.planner.schema import (
 )
 
 
+def _describe_available_node_types(
+    graph_definition: IGraphSchemaProvider,
+    requested: str,
+) -> str:
+    """Build an actionable suffix for a failed node-type binding.
+
+    A bare "failed to bind" says nothing about *why* the lookup missed.  The
+    lookup is an exact, case-sensitive match against the registered type
+    names, so the overwhelmingly common causes are a case difference or
+    stray whitespace in the schema registration.  Surfacing the registered
+    names — and any case-insensitive near-match — turns a dead end into a
+    one-line fix.
+
+    Best-effort only: providers are not required to enumerate their types,
+    so any failure here degrades to an empty suffix rather than masking the
+    original binding error.
+    """
+    try:
+        get_all = getattr(graph_definition, "get_all_node_schemas", None)
+        if get_all is None:
+            return ""
+        available = sorted(
+            schema.name for schema in get_all() if getattr(schema, "name", None)
+        )
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+    if not available:
+        return ""
+
+    near = [
+        name
+        for name in available
+        if name.strip().casefold() == requested.strip().casefold()
+    ]
+    hint = ""
+    if near:
+        hint = (
+            f" Did you mean '{near[0]}'? Node type names are matched exactly "
+            f"(case-sensitive, whitespace-sensitive)."
+        )
+
+    return f".{hint} Available node types: {', '.join(repr(n) for n in available)}"
+
+
 @dataclass
 class _BindingResult:
     """Result of binding an entity to a graph schema.
@@ -122,6 +167,7 @@ class DataSourceOperator(StartLogicalOperator, IBindable):
                 raise TranspilerBindingException(
                     f"Failed to bind entity '{node_entity.alias}' "
                     f"of type '{entity_name}'"
+                    + _describe_available_node_types(graph_definition, entity_name)
                 )
 
         # Build node ID field if available

--- a/src/gsql2rsql/renderer/procedural_bfs_renderer.py
+++ b/src/gsql2rsql/renderer/procedural_bfs_renderer.py
@@ -620,11 +620,35 @@ class ProceduralBFSRenderer:
             raise TranspilerNotSupportedException(
                 "Procedural BFS requires a finite max_hops bound."
             )
+        if op.min_hops == 0:
+            raise TranspilerNotSupportedException(
+                "Procedural BFS does not support *0..N patterns: the "
+                "depth-0 row (the start node itself) is never emitted, so "
+                "results would silently omit it. Use "
+                "vlp_rendering_mode='cte' for zero-length paths."
+            )
 
         enriched = self._get_enriched(op)
         if enriched.source_node is None:
             raise TranspilerNotSupportedException(
                 "Procedural BFS requires a resolvable start node."
+            )
+        # Single-source architecture: one global visited set plus a CROSS
+        # JOIN against the seed frontier to attribute the start node. An
+        # unfiltered source seeds EVERY node, so the visited anti-join
+        # discards all expansions (empty results) and any multi-node seed
+        # fabricates (start, end) pairs that are not connected. A start
+        # filter is therefore mandatory; cardinality is re-checked at
+        # runtime by the seed guard emitted into the script.
+        if (
+            enriched.start_filter_as_n is None
+            and enriched.start_filter_as_src is None
+        ):
+            raise TranspilerNotSupportedException(
+                "Procedural BFS is single-source: the traversal start must "
+                "be narrowed to one node by a property filter (e.g. "
+                "{origin_id: '...'}). Chained/unfiltered VLP sources are "
+                "not representable. Use vlp_rendering_mode='cte'."
             )
         if op.bidirectional_bfs_mode != "off":
             if enriched.target_node is None:
@@ -1145,6 +1169,7 @@ class ProceduralBFSRenderer:
             f"CREATE TEMPORARY TABLE bfs_frontier_{p.n}_init AS\n"
             f"SELECT node FROM bfs_frontier_{p.n};"
         )
+        lines.append(self._seed_guard(p, f"bfs_frontier_{p.n}_init"))
 
         # Keyed edge copy: materialized once, before the loop (O9). Must
         # precede the adjacency, which is built from it when both are on.
@@ -1164,6 +1189,26 @@ class ProceduralBFSRenderer:
             )
 
         return "\n".join(lines)
+
+    @staticmethod
+    def _seed_guard(p: _BFSParams, frontier_view: str) -> str:
+        """Runtime guard: fail loudly if the seed has more than one node.
+
+        The static ``_validate`` check requires a start filter, but only the
+        executed script can see how many nodes that filter actually matched.
+        With >1 seed the CROSS JOIN start attribution fabricates
+        (start, end) pairs, so wrong results must be prevented at runtime.
+        A mid-script SELECT is executed and its result discarded, which
+        makes ``IF(..., RAISE_ERROR(...), TRUE)`` a strategy-agnostic guard
+        (no DECLAREd variable needed).
+        """
+        return (
+            f"SELECT IF(COUNT(*) > 1, RAISE_ERROR("
+            f"'gsql2rsql procedural BFS is single-source but the start "
+            f"filter matched multiple nodes. "
+            f"Use vlp_rendering_mode=\"cte\" for multi-source traversals.'"
+            f"), TRUE) FROM {frontier_view};"
+        )
 
     def _tt_edge_expansion_sql(self, p: _BFSParams) -> str:
         """Build edge expansion SELECT for temp_tables (no quote escaping).
@@ -1783,7 +1828,8 @@ class ProceduralBFSRenderer:
         return (
             f"CREATE OR REPLACE TEMPORARY VIEW bfs_frontier_{p.n}_0 AS\n"
             f"SELECT n.{p.node_id_col} AS node\n"
-            f"{from_clause};"
+            f"{from_clause};\n"
+            f"{self._seed_guard(p, f'bfs_frontier_{p.n}_0')}"
         )
 
     def _nv_visited_init(self, p: _BFSParams) -> str:

--- a/src/gsql2rsql/renderer/sql_renderer.py
+++ b/src/gsql2rsql/renderer/sql_renderer.py
@@ -11,6 +11,8 @@ from gsql2rsql.common.exceptions import (
 from gsql2rsql.common.logging import ILoggable
 from gsql2rsql.parser.ast import (
     QueryExpression,
+    QueryExpressionFunction,
+    QueryExpressionListPredicate,
     QueryExpressionProperty,
 )
 from gsql2rsql.parser.operators import (
@@ -241,6 +243,7 @@ class SQLRenderer:
                 for op in self._walk_operators(start_op)
             )
             if has_recursive:
+                self._validate_procedural_path_functions(plan)
                 return self._render_plan_procedural(plan)
 
         # Collect any operators that need CTEs
@@ -320,6 +323,88 @@ class SQLRenderer:
             result.append(current)
             stack.extend(current.out_operators)
         return result
+
+    def _validate_procedural_path_functions(self, plan: LogicalPlan) -> None:
+        """Reject nodes(p)/length(p) when rendering procedurally.
+
+        Procedural BFS never reconstructs the path node array: the final
+        view emits ``CAST(NULL AS ARRAY<STRING>) AS path``, so any
+        expression consuming it — ``nodes(p)``, ``length(p)`` (rendered as
+        ``SIZE(path) - 1``) — would silently evaluate to NULL at execution.
+        ``relationships(p)`` stays supported (``path_edges`` IS built).
+        Failing at transpile time with a pointer to CTE mode beats a
+        silently-NULL result column.
+        """
+        from gsql2rsql.common.exceptions import (
+            TranspilerNotSupportedException,
+        )
+
+        all_ops = [
+            op
+            for start_op in plan.starting_operators
+            for op in self._walk_operators(start_op)
+        ]
+        path_vars = {
+            op.path_variable
+            for op in all_ops
+            if isinstance(op, RecursiveTraversalOperator) and op.path_variable
+        }
+        if not path_vars:
+            return
+
+        def find_offender(expr: QueryExpression) -> str | None:
+            # ALL/ANY/NONE/SINGLE over nodes(p) are handled by the
+            # filtered-edges pushdown (no path array read), so the
+            # nodes(p) list head there is NOT an offender; the inner
+            # predicate is still walked (it binds the lambda variable,
+            # not the path).
+            if isinstance(expr, QueryExpressionListPredicate):
+                if expr.filter_expression is not None:
+                    return find_offender(expr.filter_expression)
+                return None
+            if isinstance(expr, QueryExpressionFunction) and expr.function in (
+                Function.NODES,
+                Function.LENGTH,
+            ):
+                for param in expr.parameters:
+                    if (
+                        isinstance(param, QueryExpressionProperty)
+                        and param.property_name is None
+                        and param.variable_name in path_vars
+                    ):
+                        return (
+                            "nodes"
+                            if expr.function == Function.NODES
+                            else "length"
+                        )
+            for child in expr.children:
+                if isinstance(child, QueryExpression):
+                    found = find_offender(child)
+                    if found:
+                        return found
+            return None
+
+        for op in all_ops:
+            for value in vars(op).values():
+                candidates: list[Any] = (
+                    list(value) if isinstance(value, (list, tuple)) else [value]
+                )
+                for item in candidates:
+                    if isinstance(item, tuple):
+                        candidates.extend(item)
+                        continue
+                    if not isinstance(item, QueryExpression):
+                        continue
+                    offender = find_offender(item)
+                    if offender:
+                        raise TranspilerNotSupportedException(
+                            f"{offender}(<path>) requires the path node "
+                            f"array, which procedural BFS does not build "
+                            f"(the path column is NULL). Use "
+                            f"vlp_rendering_mode='cte', or restructure the "
+                            f"query around relationships(<path>), which "
+                            f"procedural mode supports."
+                        )
 
     def _render_plan_procedural(self, plan: LogicalPlan) -> str:
         """Render plan using procedural BFS instead of WITH RECURSIVE CTEs."""

--- a/tests/test_backtick_escaped_names.py
+++ b/tests/test_backtick_escaped_names.py
@@ -1,0 +1,304 @@
+"""Tests for backtick-escaped names (openCypher EscapedSymbolicName).
+
+openCypher allows any identifier to be escaped with backticks:
+
+    MATCH (n:`My Label`)-[r:`MY REL`]->(`other node`)
+    RETURN n.`first name`
+
+The backticks are *delimiters*, not part of the name.  A label written as
+``:`cnpj_raiz``` must bind to the node type ``cnpj_raiz``, exactly as the
+unescaped ``:cnpj_raiz`` does.  Failing to strip them produces a schema
+lookup for the literal string ```cnpj_raiz``` which can never match, and
+surfaces as a confusing "Failed to bind entity" error even though the type
+is correctly registered.
+"""
+
+import pytest
+
+from gsql2rsql.graph_context import GraphContext
+from gsql2rsql.parser.opencypher_parser import OpenCypherParser
+
+
+def _collect_entity_names(ast: object) -> list[str]:
+    """Walk an AST collecting every non-empty ``entity_name``."""
+    found: list[str] = []
+    seen: set[int] = set()
+
+    def walk(node: object, depth: int = 0) -> None:
+        if depth > 8 or id(node) in seen:
+            return
+        seen.add(id(node))
+        name = getattr(node, "entity_name", None)
+        if isinstance(name, str) and name:
+            found.append(name)
+        for attr in ("entities", "match_clauses", "clauses", "children"):
+            value = getattr(node, attr, None)
+            if isinstance(value, list):
+                for child in value:
+                    walk(child, depth + 1)
+
+    walk(ast)
+    return found
+
+
+class TestBacktickStripping:
+    """Backticks must be removed from parsed identifiers."""
+
+    def test_node_label_backticks_stripped(self) -> None:
+        """`:`cnpj_raiz`` must yield entity_name 'cnpj_raiz', not '`cnpj_raiz`'."""
+        ast = OpenCypherParser().parse("MATCH (root:`cnpj_raiz`) RETURN root")
+        names = _collect_entity_names(ast)
+        assert names, "expected at least one entity_name in the AST"
+        for name in names:
+            assert "`" not in name, f"backticks leaked into entity_name: {name!r}"
+        assert "cnpj_raiz" in names
+
+    def test_node_label_with_spaces(self) -> None:
+        """Backticks are what make spaces legal inside a label."""
+        ast = OpenCypherParser().parse("MATCH (n:`My Label`) RETURN n")
+        assert "My Label" in _collect_entity_names(ast)
+
+    def test_relationship_type_backticks_stripped(self) -> None:
+        """Relationship types are escaped the same way as node labels."""
+        ast = OpenCypherParser().parse("MATCH (a)-[r:`MY REL`]->(b) RETURN r")
+        names = _collect_entity_names(ast)
+        for name in names:
+            assert "`" not in name, f"backticks leaked into entity_name: {name!r}"
+        assert "MY REL" in names
+
+    def test_unescaped_label_unaffected(self) -> None:
+        """The common unescaped path must not regress."""
+        ast = OpenCypherParser().parse("MATCH (root:cnpj_raiz) RETURN root")
+        assert "cnpj_raiz" in _collect_entity_names(ast)
+
+
+class TestBacktickBinding:
+    """An escaped label must bind against the registered node type."""
+
+    @staticmethod
+    def _graph() -> GraphContext:
+        graph = GraphContext(
+            nodes_table="nodes",
+            edges_table="edges",
+            node_type_col="node_type",
+            node_id_col="origin_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="relationship_type",
+        )
+        graph.set_types(
+            node_types=["cnpj_raiz", "socio"],
+            edge_types=["OWNS"],
+        )
+        return graph
+
+    def test_escaped_label_binds_in_vlp_query(self) -> None:
+        """Regression: escaped label + multi-MATCH VLP must transpile.
+
+        This is the exact shape that failed: the type IS registered, so the
+        only reason binding could fail is the backticks reaching the schema
+        lookup.
+        """
+        query = """
+        MATCH (root:`cnpj_raiz` {origin_id: '04906728'})
+        MATCH (root)-[*1..2]-(d)
+        RETURN count(DISTINCT d) AS total
+        """
+        sql = self._graph().transpile(query)
+        assert "`cnpj_raiz`" not in sql
+        assert "node_type = 'cnpj_raiz'" in sql
+
+    def test_escaped_and_unescaped_produce_same_sql(self) -> None:
+        """Backticks are delimiters only — they must not change the output."""
+        graph = self._graph()
+        escaped = graph.transpile(
+            "MATCH (root:`cnpj_raiz`) RETURN root.origin_id AS id"
+        )
+        plain = graph.transpile(
+            "MATCH (root:cnpj_raiz) RETURN root.origin_id AS id"
+        )
+        assert escaped == plain
+
+
+class TestBacktickAcrossConstructs:
+    """Backticks must be stripped wherever an identifier can appear.
+
+    Identifier extraction is scattered across many ``getText()`` sites in the
+    visitor (properties, expression variables, map keys, aliases…).  Each of
+    these queries failed with ``ColumnResolutionError`` before unescaping was
+    applied at every site, because the leaked backticks made the name miss
+    the schema/scope lookup.
+    """
+
+    @staticmethod
+    def _graph() -> GraphContext:
+        graph = GraphContext(
+            nodes_table="nodes",
+            edges_table="edges",
+            node_type_col="node_type",
+            node_id_col="node_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="rel_type",
+            extra_node_attrs={"age": int, "name": str},
+        )
+        graph.set_types(node_types=["Person"], edge_types=["KNOWS", "OWNS"])
+        return graph
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # property access in RETURN
+            "MATCH (n:Person) RETURN n.`age` AS a",
+            # property access inside an arithmetic expression
+            "MATCH (n:Person) RETURN n.`age` + 1 AS a",
+            # property access in WHERE
+            "MATCH (n:Person) WHERE n.`age` > 1 RETURN n.age AS a",
+            # inline property (map literal) key
+            "MATCH (n:Person {`age`: 30}) RETURN n.age AS a",
+            # escaped WITH alias, then referenced escaped
+            "MATCH (n:Person) WITH n.age AS `my age` RETURN `my age` AS a",
+            # escaped variable declared in MATCH and referenced in RETURN
+            "MATCH (`my n`:Person) RETURN `my n`.age AS a",
+            # escaped OR relationship types
+            "MATCH (a:Person)-[r:`KNOWS`|`OWNS`]->(b) RETURN a.age AS x",
+            # escaped type inside a VLP quantifier
+            "MATCH (a:Person)-[:`KNOWS`*1..2]->(b) RETURN b.age AS x",
+            # escaped alias referenced in ORDER BY
+            "MATCH (n:Person) RETURN n.age AS `my age` ORDER BY `my age`",
+            # UNWIND with escaped alias (needs a leading MATCH: standalone
+            # UNWIND is an unrelated pre-existing planner limitation)
+            "MATCH (n:Person) UNWIND [1, 2] AS `my x` RETURN `my x` AS v",
+        ],
+    )
+    def test_escaped_identifier_transpiles(self, query: str) -> None:
+        # None of these schemas/tables contain a literal backtick, so any
+        # backtick in the output is a leaked delimiter.
+        sql = self._graph().transpile(query)
+        assert "`" not in sql, f"backtick leaked into SQL:\n{sql}"
+
+    def test_doubled_backtick_is_literal_backtick(self) -> None:
+        """`` `Per``son` `` names the type ``Per`son`` (escaped backtick)."""
+        ast = OpenCypherParser().parse("MATCH (n:`Per``son`) RETURN n")
+        assert "Per`son" in _collect_entity_names(ast)
+
+
+class TestBacktickedTableNamesPreserved:
+    """Unescaping Cypher identifiers must NOT touch SQL table names.
+
+    Table names come from schema configuration (``SQLTableDescriptor``) and
+    never pass through the Cypher parser, so a catalog that requires
+    backtick-quoting in Databricks SQL (e.g. a hyphenated catalog name) must
+    reach the rendered SQL verbatim.
+    """
+
+    @staticmethod
+    def _graph() -> GraphContext:
+        graph = GraphContext(
+            nodes_table="`catalogo-algo`.schema.nodes",
+            edges_table="`catalogo-algo`.schema.edges",
+            node_type_col="node_type",
+            node_id_col="node_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="rel_type",
+            extra_node_attrs={"origin_id": str},
+        )
+        graph.set_types(node_types=["CNPJ_RAIZ"], edge_types=["OWNS"])
+        return graph
+
+    def test_simple_match_keeps_table_backticks(self) -> None:
+        sql = self._graph().transpile(
+            "MATCH (n:CNPJ_RAIZ) RETURN n.origin_id AS a"
+        )
+        assert "`catalogo-algo`.schema.nodes" in sql
+        assert "catalogo-algo.schema" not in sql.replace(
+            "`catalogo-algo`.schema", ""
+        ), "table name lost its backticks somewhere"
+
+    def test_vlp_keeps_table_backticks_everywhere(self) -> None:
+        """The recursive CTE references the tables many times — all quoted."""
+        sql = self._graph().transpile(
+            "MATCH (root:CNPJ_RAIZ {origin_id: 'x'}) "
+            "MATCH (root)-[*1..2]-(d) RETURN count(DISTINCT d)"
+        )
+        assert sql.count("`catalogo-algo`.schema") >= 4
+        assert "catalogo-algo.schema" not in sql.replace(
+            "`catalogo-algo`.schema", ""
+        )
+
+    def test_escaped_label_and_backticked_table_coexist(self) -> None:
+        """Label backticks are stripped; table backticks are kept."""
+        sql = self._graph().transpile(
+            "MATCH (n:`CNPJ_RAIZ`) RETURN n.origin_id AS a"
+        )
+        assert "`catalogo-algo`.schema.nodes" in sql
+        assert "`CNPJ_RAIZ`" not in sql
+        assert "node_type = 'CNPJ_RAIZ'" in sql
+
+    def test_hyphenated_node_type_requires_and_survives_escaping(self) -> None:
+        """A type like ``cnpj-raiz`` is only expressible via backticks.
+
+        After unescaping, the lookup matches the registered name and the
+        rendered filter is a plain string literal — no SQL quoting needed.
+        """
+        graph = GraphContext(
+            nodes_table="nodes",
+            edges_table="edges",
+            node_type_col="node_type",
+            node_id_col="node_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="rel_type",
+            extra_node_attrs={"origin_id": str},
+        )
+        graph.set_types(node_types=["cnpj-raiz"], edge_types=["OWNS"])
+        sql = graph.transpile("MATCH (n:`cnpj-raiz`) RETURN n.origin_id AS a")
+        assert "node_type = 'cnpj-raiz'" in sql
+
+
+class TestUnknownLabelErrorMessage:
+    """A genuinely unknown label must fail with an actionable message."""
+
+    def test_error_lists_available_node_types(self) -> None:
+        """The error should name the registered types, not just the failure."""
+        graph = GraphContext(
+            nodes_table="nodes",
+            edges_table="edges",
+            node_type_col="node_type",
+            node_id_col="origin_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="relationship_type",
+        )
+        graph.set_types(node_types=["socio"], edge_types=["OWNS"])
+
+        with pytest.raises(Exception) as exc_info:
+            graph.transpile("MATCH (root:cnpj_raiz) RETURN root")
+
+        message = str(exc_info.value)
+        assert "cnpj_raiz" in message
+        assert "socio" in message, (
+            f"error should list available node types, got: {message}"
+        )
+
+    def test_error_suggests_case_insensitive_match(self) -> None:
+        """A case-only mismatch is the most common cause — say so explicitly."""
+        graph = GraphContext(
+            nodes_table="nodes",
+            edges_table="edges",
+            node_type_col="node_type",
+            node_id_col="origin_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="relationship_type",
+        )
+        graph.set_types(node_types=["CNPJ_RAIZ"], edge_types=["OWNS"])
+
+        with pytest.raises(Exception) as exc_info:
+            graph.transpile("MATCH (root:cnpj_raiz) RETURN root")
+
+        message = str(exc_info.value)
+        assert "CNPJ_RAIZ" in message, (
+            f"error should surface the near-match, got: {message}"
+        )

--- a/tests/test_procedural_mode_guardrails.py
+++ b/tests/test_procedural_mode_guardrails.py
@@ -1,0 +1,121 @@
+"""Guardrails for constructs the procedural BFS renderer cannot represent.
+
+The procedural BFS architecture is single-source: one global visited set and
+a ``CROSS JOIN`` against the seed frontier to attribute the start node.  Some
+openCypher constructs silently produced WRONG results under it (empirically
+verified against CTE mode on PySpark):
+
+- ``length(p)`` / ``nodes(p)`` returned NULL (the ``path`` column is emitted
+  as ``CAST(NULL AS ARRAY<STRING>)``);
+- ``*0..N`` omitted the depth-0 row (the start node itself);
+- an unfiltered VLP source seeded EVERY node, so the visited anti-join
+  discarded all expansions (chained ``MATCH (a)-[*..]->(b) MATCH (b)-[*..]->``
+  returned empty) — and with a few seeds the CROSS JOIN fabricated
+  (start, end) pairs that are not connected at all.
+
+A transpiler must never return wrong results silently: these now raise
+``TranspilerNotSupportedException`` at transpile time (pointing to CTE mode),
+plus a runtime single-seed guard inside the generated script for cardinality
+only known at execution.  CTE mode keeps supporting all of these constructs.
+"""
+
+import pytest
+
+from gsql2rsql.common.exceptions import TranspilerNotSupportedException
+from gsql2rsql.graph_context import GraphContext
+
+PROC = {"vlp_rendering_mode": "procedural",
+        "materialization_strategy": "numbered_views"}
+
+
+def _graph() -> GraphContext:
+    graph = GraphContext(
+        nodes_table="nodes",
+        edges_table="edges",
+        node_type_col="node_type",
+        node_id_col="node_id",
+        edge_src_col="source_node_id",
+        edge_dst_col="target_node_id",
+        edge_type_col="relationship_type",
+        extra_node_attrs={"origin_id": str},
+    )
+    graph.set_types(node_types=["CNPJ_RAIZ", "socio"], edge_types=["OWNS"])
+    return graph
+
+
+ROOT = "MATCH (root:CNPJ_RAIZ {origin_id: 'x'})\n"
+
+
+class TestPathFunctionsProcedural:
+    """nodes(p)/length(p) need the path array, which procedural never builds."""
+
+    def test_length_p_raises_in_procedural(self) -> None:
+        query = (ROOT + "MATCH p = (root)-[*1..2]-(d) "
+                 "RETURN DISTINCT length(p) AS l")
+        with pytest.raises(TranspilerNotSupportedException, match="length"):
+            _graph().transpile(query, **PROC)
+
+    def test_nodes_p_raises_in_procedural(self) -> None:
+        query = (ROOT + "MATCH p = (root)-[*1..2]-(d) "
+                 "RETURN DISTINCT size(nodes(p)) AS s")
+        with pytest.raises(TranspilerNotSupportedException, match="nodes"):
+            _graph().transpile(query, **PROC)
+
+    def test_relationships_p_still_supported_in_procedural(self) -> None:
+        """relationships(p) uses path_edges, which procedural DOES build."""
+        query = (ROOT + "MATCH p = (root)-[*1..2]-(d) "
+                 "UNWIND relationships(p) AS r "
+                 "RETURN DISTINCT r.source_node_id AS a")
+        sql = _graph().transpile(query, **PROC)
+        assert "path_edges" in sql
+
+    def test_length_and_nodes_work_in_cte_mode(self) -> None:
+        for ret in ("length(p) AS l", "size(nodes(p)) AS s"):
+            query = (ROOT + f"MATCH p = (root)-[*1..2]-(d) "
+                     f"RETURN DISTINCT {ret}")
+            assert _graph().transpile(query, vlp_rendering_mode="cte")
+
+
+class TestZeroMinHopsProcedural:
+    """*0..N includes the start node itself; procedural never emits depth 0."""
+
+    def test_zero_min_hops_raises_in_procedural(self) -> None:
+        query = ROOT + "MATCH (root)-[*0..2]-(d) RETURN DISTINCT d"
+        with pytest.raises(TranspilerNotSupportedException, match="0"):
+            _graph().transpile(query, **PROC)
+
+    def test_zero_min_hops_works_in_cte(self) -> None:
+        query = (ROOT + "MATCH (root)-[*0..2]-(d) "
+                 "RETURN DISTINCT d.origin_id AS v")
+        assert _graph().transpile(query, vlp_rendering_mode="cte")
+
+
+class TestUnfilteredSourceProcedural:
+    """Unfiltered source seeds every node — the single-source design breaks."""
+
+    def test_chained_vlp_raises_in_procedural(self) -> None:
+        query = ("MATCH (a:CNPJ_RAIZ {origin_id: 'x'})-[*1..1]->(b) "
+                 "MATCH (b)-[*1..1]->(c) RETURN DISTINCT c.origin_id AS v")
+        with pytest.raises(TranspilerNotSupportedException):
+            _graph().transpile(query, **PROC)
+
+    def test_chained_vlp_works_in_cte(self) -> None:
+        query = ("MATCH (a:CNPJ_RAIZ {origin_id: 'x'})-[*1..1]->(b) "
+                 "MATCH (b)-[*1..1]->(c) RETURN DISTINCT c.origin_id AS v")
+        assert _graph().transpile(query, vlp_rendering_mode="cte")
+
+    def test_filtered_source_still_supported(self) -> None:
+        """The normal single-root case must keep working in procedural."""
+        query = ROOT + "MATCH (root)-[*1..2]-(d) RETURN count(DISTINCT d)"
+        assert _graph().transpile(query, **PROC)
+
+
+class TestRuntimeSingleSeedGuard:
+    """A filter can still match >1 node — only the script can check that."""
+
+    def test_generated_script_contains_seed_guard(self) -> None:
+        query = ROOT + "MATCH (root)-[*1..2]-(d) RETURN count(DISTINCT d)"
+        sql = _graph().transpile(query, **PROC)
+        assert "RAISE_ERROR" in sql.upper(), (
+            "procedural script must guard against multi-node seeds at runtime"
+        )

--- a/tests/test_unaliased_projection_alias.py
+++ b/tests/test_unaliased_projection_alias.py
@@ -1,0 +1,118 @@
+"""Tests for RETURN items that carry no explicit AS alias.
+
+openCypher lets any expression be returned without an alias::
+
+    RETURN count(DISTINCT d)
+    RETURN count(*)
+    RETURN n.age + 1
+
+The column is then named after the expression text.  Emitting an empty
+alias produces ``SELECT COUNT(DISTINCT x) AS  FROM ...`` — a hard SQL
+syntax error ("Invalid expression / Unexpected token") that only surfaces
+at execution time, well after transpilation appears to succeed.
+
+Property access (``RETURN n.name``) already derived an alias; the gap was
+every *other* unaliased expression, aggregations above all.
+"""
+
+import re
+
+import pytest
+
+from gsql2rsql.graph_context import GraphContext
+
+
+def _graph() -> GraphContext:
+    graph = GraphContext(
+        nodes_table="nodes",
+        edges_table="edges",
+        node_type_col="node_type",
+        node_id_col="node_id",
+        edge_src_col="source_node_id",
+        edge_dst_col="target_node_id",
+        edge_type_col="relationship_type",
+        extra_node_attrs={"origin_id": str, "age": int},
+    )
+    graph.set_types(
+        node_types=["CNPJ_RAIZ", "socio"],
+        edge_types=["OWNS"],
+    )
+    return graph
+
+
+#: ``AS`` followed by end-of-line, a comma, or a closing/FROM keyword.
+_EMPTY_ALIAS = re.compile(r"\bAS\s*(?=$|\n|,|\)|FROM\b)", re.MULTILINE)
+
+
+def assert_no_empty_alias(sql: str) -> None:
+    """Fail if the SQL contains a dangling ``AS`` with no alias name."""
+    match = _EMPTY_ALIAS.search(sql)
+    assert match is None, (
+        "SQL contains an empty alias (`AS` with no name) at offset "
+        f"{match.start() if match else -1}:\n"
+        f"...{sql[max(0, (match.start() if match else 0) - 120):][:240]}..."
+    )
+
+
+class TestUnaliasedAggregations:
+    """Aggregations without AS must still get a column name."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "MATCH (n:CNPJ_RAIZ) RETURN count(DISTINCT n)",
+            "MATCH (n:CNPJ_RAIZ) RETURN count(n)",
+            "MATCH (n:CNPJ_RAIZ) RETURN count(*)",
+            "MATCH (n:CNPJ_RAIZ) RETURN max(n.age)",
+            "MATCH (n:CNPJ_RAIZ) RETURN count(DISTINCT n.origin_id)",
+        ],
+    )
+    def test_aggregation_without_alias(self, query: str) -> None:
+        """Each aggregation form must render a non-empty alias."""
+        assert_no_empty_alias(_graph().transpile(query))
+
+    def test_user_reported_vlp_count(self) -> None:
+        """Regression: the exact reported query.
+
+        ``MATCH ... MATCH (root)-[*1..2]-(d) RETURN count(DISTINCT d)``
+        transpiled to ``COUNT(DISTINCT ...) AS  FROM`` and failed at
+        execution with a syntax error.
+        """
+        query = """
+        MATCH (root:CNPJ_RAIZ {origin_id: 'xx'})
+        MATCH (root)-[*1..2]-(d)
+        RETURN count(DISTINCT d)
+        """
+        assert_no_empty_alias(_graph().transpile(query))
+
+
+class TestUnaliasedExpressions:
+    """Non-aggregate expressions without AS must also get a name."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "MATCH (n:CNPJ_RAIZ) RETURN n.age + 1",
+            "MATCH (n:CNPJ_RAIZ) RETURN 42",
+            "MATCH (n:CNPJ_RAIZ) RETURN toUpper(n.origin_id)",
+        ],
+    )
+    def test_expression_without_alias(self, query: str) -> None:
+        assert_no_empty_alias(_graph().transpile(query))
+
+
+class TestAliasedProjectionsUnaffected:
+    """The explicit-alias and property paths must not regress."""
+
+    def test_explicit_alias_preserved(self) -> None:
+        sql = _graph().transpile(
+            "MATCH (n:CNPJ_RAIZ) RETURN count(DISTINCT n) AS total"
+        )
+        assert_no_empty_alias(sql)
+        assert "AS total" in sql
+
+    def test_property_alias_still_derived(self) -> None:
+        """RETURN n.origin_id keeps naming the column after the property."""
+        sql = _graph().transpile("MATCH (n:CNPJ_RAIZ) RETURN n.origin_id")
+        assert_no_empty_alias(sql)
+        assert "origin_id" in sql


### PR DESCRIPTION
Three parser-phase defects and a set of procedural-BFS correctness guardrails, all found while diagnosing a "Failed to bind entity" error on a real MATCH ... MATCH (root)-[*1..2]-(d) RETURN count(DISTINCT d) query.

Parser (visitor.py):
- Backtick-escaped identifiers (`Label`, `prop`, `variable`) leaked their delimiters into entity_name/alias, so a correctly-registered node type like `cnpj_raiz` failed to bind because the lookup used the literal string with backticks still attached. Added unescape_symbolic_name()/split_escaped_labels() and applied them at every identifier extraction site: node labels, relationship types (OR-joined), variables, property lookups, map literal keys, UNWIND/ path/REDUCE/list-comprehension variables. Table names (which come from schema config, not the Cypher text) are untouched.
- Unaliased projections (RETURN count(*), RETURN n.age + 1, ...) via the live visit_oC_ProjectionItem path emitted an empty AS alias, producing a SQL syntax error only at execution time. Added sanitize_expression_alias() to derive a column name from the raw Cypher expression text, matching the fallback the legacy (dead) visit_oC_ReturnItem path already had.

Planner (data_source.py):
- Binding failure on an unknown node type now lists the registered types and flags a case-insensitive near-match, instead of a bare "Failed to bind entity" with no actionable next step.

Renderer (procedural_bfs_renderer.py, sql_renderer.py):
- Procedural BFS's single-source architecture (one global visited set
  + CROSS JOIN frontier attribution) silently produced wrong results for constructs CTE mode handles correctly: unfiltered/chained VLP sources fabricated (start, end) pairs or returned empty, *0..N omitted the start node, and length(p)/nodes(p) evaluated to NULL. Added transpile-time NotSupportedException for all three (pointing callers at vlp_rendering_mode="cte"), plus a runtime seed-cardinality guard (RAISE_ERROR) since a start filter can still match >1 node. relationships(p) and ALL(n IN nodes(p) WHERE ...) pushdown remain supported in procedural mode.

Verified: pyright/mypy 0 errors; 1738 passed (was 1694) + 7 skipped + 1 xfailed on the non-PySpark suite; 220 passed + 5 xfailed on PySpark. Dual-mode (CTE vs procedural) A/B executed on real PySpark data across ~30 query variations with hand-computed expected results — no divergence or wrong result survives after these fixes.

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature (triggers minor version bump)
- [ ] `fix`: Bug fix (triggers patch version bump)
- [ ] `perf`: Performance improvement (triggers patch version bump)
- [ ] `docs`: Documentation only changes
- [ ] `style`: Code style changes (formatting, missing semi colons, etc)
- [ ] `refactor`: Code refactoring without functionality changes
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `ci`: Changes to CI configuration files and scripts

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes -->

- [ ] Unit tests pass (`make test-no-pyspark`)
- [ ] PySpark tests pass (`make test-pyspark`)
- [ ] Linting passes (`make lint`)
- [ ] Type checking passes (`make typecheck`)

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related Issues

<!-- Link any related issues here. Use "Closes #123" to auto-close issues when merged -->

Closes #
