### PR TITLE
fix: backtick unaliased projection procedural guardrails

### DIFF
--- a/.claude/skills/fix_transpiler_bugs/SKILL.md
+++ b/.claude/skills/fix_transpiler_bugs/SKILL.md
@@ -266,6 +266,32 @@ uv run pytest tests -n 8 -v
 # - EITHER_AS_SOURCE/SINK: Single-hop uses UNION ALL expansion
 ```
 
+### 7. Update Limitations Docs (MANDATORY when applicable)
+
+Two documents track limitations, with different audiences:
+
+| File | Audience | Published |
+|------|----------|-----------|
+| `docs_help_dev/limitations.md` | Developers (internal) | No |
+| `docs/limitations.md` | Users (mkdocs site, nav: User Guide → Limitations) | Yes |
+
+**Update BOTH whenever the fix:**
+
+- adds a `TranspilerNotSupportedException` or any guardrail (static or
+  runtime `RAISE_ERROR`) — the construct is now a *documented* limitation;
+- reveals a pre-existing unsupported construct (even if you don't fix it);
+- REMOVES a limitation (feature now works) — delete/update stale entries;
+- changes which constructs work per rendering mode — keep the
+  **CTE vs Procedural matrix** in `docs/limitations.md` in sync;
+- improves an error message users will see — the "error messages" section
+  of `docs/limitations.md` shows real message examples; keep them accurate.
+
+**Why:** a limitation that only exists as an exception in code is invisible
+until a user hits it. Silent-wrong-result bugs converted to loud errors
+(the preferred pattern) MUST land in the user-facing doc in the same PR.
+
+Verify the site still builds: `uv run mkdocs build` (no NEW warnings).
+
 ---
 
 ## Test Categories to Cover
@@ -367,6 +393,9 @@ assert results == {"Alice", "Carol", "Eve"}  # Exact expected values
 * The fix is explained with a root-cause diagnosis and a trade-off analysis.
 * The solution preserves (or documents deliberate, justified changes to) the Separation of Concerns.
 * Tests added/changed are reviewed and are robust (not flaky).
+* If the fix added/removed a limitation, guardrail, or `NotSupported` path,
+  BOTH `docs_help_dev/limitations.md` and `docs/limitations.md` are updated
+  (see step 7) and `uv run mkdocs build` passes with no new warnings.
 
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -27,6 +27,12 @@ Databricks SQL. Anything that mutates the graph is out of scope by design.
 | Geospatial (`point()`, `distance()`) | ❌ | Use Databricks geospatial SQL directly |
 | `!=` operator | ❌ deliberate | Use `<>` — `!=` is rejected as a syntax error |
 | Standalone `UNWIND ... RETURN` (no `MATCH`) | ❌ | Fails with "Empty partial query" |
+| `percentileCont()`, `percentileDisc()` | ✅ | `PERCENTILE_CONT/DISC ... WITHIN GROUP` |
+| `LIMIT $n` / `SKIP $n` (parameters) | ❌ | Inline the value — rejected with a clear error |
+| Label predicates `WHERE a:Person` | ❌ | Move the label into the pattern: `MATCH (a:Person)` |
+| `split()`, `substring()`, `replace()`, `reverse()`, `head()`, `tail()`, `keys()`, `labels()`, `id()`, `properties()` | ❌ | Rejected with an error naming the function |
+| Unbounded VLP `-[:TYPE*]->` | ⚠️ | Silently capped at 10 hops — write an explicit bound (`*1..15` is honoured as-is) |
+| Relationship uniqueness (edge isomorphism) | ⚠️ | Not enforced — see [Correctness Caveats](#correctness-caveats) |
 
 ---
 
@@ -129,6 +135,14 @@ Two edge-type situations behave differently on purpose:
   expression text: `RETURN count(DISTINCT d)` produces a column called
   `count_DISTINCT_d`, `count(*)` produces `count_star`. Add `AS name` to
   control the output column name.
+- **Colliding unaliased property projections are qualified**: in
+  `RETURN a.name, b.name` both columns would be called `name`, so they
+  become `a_name` and `b_name`. A single `RETURN p.name` still produces
+  `name`. Explicit `AS` aliases are never rewritten.
+- **`RETURN *` / `WITH *` expand to the named variables in scope** —
+  nodes and relationships project as structs of their properties, the
+  same as `RETURN a`. Anonymous pattern parts and named path variables
+  are not included.
 - **Multi-label syntax is not supported**: `(a:Person:Company)` silently
   uses only the first label and `(a:Person|Company)` is a parser error.
   Workaround: `WHERE a.node_type IN ['Person', 'Company']`.
@@ -150,6 +164,19 @@ Two edge-type situations behave differently on purpose:
   single aggregation; explicitly alias every aggregated column.
 - **Self-loops in undirected patterns** (`(a)-[:KNOWS]-(a)`) may appear
   twice in results due to the UNION ALL expansion.
+- **Relationship uniqueness (edge isomorphism) is not enforced** in
+  fixed-length patterns. openCypher requires each relationship in a
+  `MATCH` pattern to bind a distinct edge; the transpiler can reuse one
+  edge for several pattern relationships. Example: with a single
+  self-loop edge `A→A`, `MATCH (a)-[:T]->(b)-[:T]->(a)` matches by using
+  that edge for both hops, where openCypher would return nothing.
+  Variable-length paths are unaffected (the `visited` array prevents
+  node revisits).
+- **Unbounded variable-length paths are depth-capped at 10**: `*` and
+  `*2..` are rewritten to a maximum of 10 hops with no warning, so paths
+  longer than 10 are silently absent. Explicit bounds are honoured
+  exactly, including above 10 (`*1..15` renders `depth < 15`). Always
+  write an explicit upper bound for graphs whose diameter may exceed 10.
 
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -92,6 +92,31 @@ and the query works.
     `gsql2rsql procedural BFS is single-source but the start filter matched
     multiple nodes` rather than fabricating unreachable (start, end) pairs.
 
+### Multi-source traversals in procedural mode
+
+A property filter like `{DeviceType: 'desktop'}` **transpiles** fine in
+procedural mode — the transpiler cannot know how many rows it matches —
+but hits the runtime guard above as soon as it matches more than one node.
+The procedural BFS tables (`frontier`, `visited`, result) carry no seed
+column, so with several seeds every discovered node would be attributed to
+every seed (a cross join of wrong answers). Options today:
+
+1. **Use CTE mode** (`vlp_rendering_mode="cte"` or just drop the
+   argument). This is the right tool for multi-source, and for shallow
+   traversals (`*1..2`, `*1..3`) it is also the faster one — procedural
+   mode only pays off on *deep* traversals.
+2. **Loop per seed** from the driver: fetch the matching ids first, then
+   run the procedural query once per seed with
+   `{node_id: '<id>'}` and union the results. Correct, but costs
+   `seeds × BFS` with no shared work.
+
+Lifting the limitation properly means adding a `seed` column to the
+frontier/visited/result tables (what CTE mode already does with
+`start_node`). The blocker is not the rewrite itself but that every
+procedural memory optimization was designed and A/B-validated for the
+single-column frontier — see the developer notes in
+`docs_help_dev/limitations.md` if you plan to work on this.
+
 ---
 
 ## Schema Binding Errors

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,197 @@
+# Limitations
+
+What the transpiler does not support, what only works in specific rendering
+modes, and how to read the error messages designed to catch these cases
+early.
+
+The transpiler is **read-only**: it turns openCypher `MATCH` queries into
+Databricks SQL. Anything that mutates the graph is out of scope by design.
+
+---
+
+## Quick Reference
+
+| Feature | Status | Notes |
+|---|---|---|
+| `MATCH`, `WHERE`, `RETURN`, `WITH`, `UNWIND`, `ORDER BY`, `SKIP`, `LIMIT` | ✅ | Core pipeline |
+| Variable-length paths `-[:TYPE*1..N]->` | ✅ | Requires `WITH RECURSIVE` (Databricks Runtime 17+) |
+| Undirected and multi-type edges `-[:A\|B]-` | ✅ | UNION ALL expansion |
+| `relationships(p)`, `length(p)`, `nodes(p)` | ✅ CTE mode | See [rendering-mode matrix](#cte-vs-procedural-rendering-modes) |
+| Backtick-escaped identifiers `` (n:`my label`) `` | ✅ | Delimiters stripped per openCypher |
+| `CREATE`, `DELETE`, `SET`, `REMOVE`, `MERGE`, `FOREACH` | ❌ | Write operations — use SQL DML directly |
+| `shortestPath()`, `allShortestPaths()` | ❌ | Workaround: bounded BFS + `ORDER BY length(p) LIMIT 1` |
+| `CALL` procedures (APOC) | ❌ | Neo4j-specific |
+| Multi-label nodes `(a:Person:Company)` | ❌ | Workaround: `WHERE a.node_type IN [...]` |
+| Map projections `n{.id, .name}` | ❌ | Workaround: `{id: n.id, name: n.name}` |
+| `duration()`, temporal arithmetic | ⚠️ | Basic datetime functions only |
+| Geospatial (`point()`, `distance()`) | ❌ | Use Databricks geospatial SQL directly |
+| `!=` operator | ❌ deliberate | Use `<>` — `!=` is rejected as a syntax error |
+| Standalone `UNWIND ... RETURN` (no `MATCH`) | ❌ | Fails with "Empty partial query" |
+
+---
+
+## Runtime Requirements
+
+- **Databricks Runtime 17+** (or Spark 4.x) for `WITH RECURSIVE` — required
+  by every variable-length path query.
+- **Spark SQL scripting** (`spark.sql.scripting.enabled=true`, PySpark 4.2+)
+  for the procedural BFS mode (`vlp_rendering_mode="procedural"`).
+- Generated SQL uses Databricks-specific functions (`array_contains`,
+  `CONCAT` on arrays, `STRUCT`, `NAMED_STRUCT`) and is **not portable** to
+  other databases without modification.
+
+Recursion limits are Spark-version dependent: Spark 4.x defaults to 100
+iterations (`RECURSION_LEVEL_LIMIT_EXCEEDED`); older versions cap rows per
+iteration. The [bidirectional BFS](#deep-variable-length-paths) option
+exists specifically to work around these limits.
+
+---
+
+## CTE vs Procedural Rendering Modes
+
+Variable-length paths can be rendered two ways, selected per query:
+
+```python
+graph.transpile(query)                                   # CTE (default)
+graph.transpile(query, vlp_rendering_mode="procedural",
+                materialization_strategy="numbered_views")
+```
+
+**CTE mode** (`WITH RECURSIVE`) is the default and supports every VLP
+construct. **Procedural mode** (a `BEGIN…END` BFS loop) is a performance
+option for deep traversals from a **single start node** — its architecture
+keeps one global visited set and attributes every discovered node to the
+seed, which makes several constructs unrepresentable. Those cases fail
+loudly instead of returning wrong results:
+
+| Construct | CTE | Procedural |
+|---|---|---|
+| `count(DISTINCT d)`, filters, aggregations over VLP | ✅ | ✅ |
+| `relationships(p)` + `UNWIND` | ✅ | ✅ |
+| `ALL(n IN nodes(p) WHERE ...)` predicate pushdown | ✅ | ✅ |
+| `length(p)` | ✅ | ❌ transpile-time error |
+| `nodes(p)` / `size(nodes(p))` | ✅ | ❌ transpile-time error |
+| `*0..N` (zero-length paths include the start node) | ✅ | ❌ transpile-time error |
+| Unfiltered / chained VLP source (`MATCH (a)-[*]->(b) MATCH (b)-[*]->(c)`) | ✅ | ❌ transpile-time error |
+| Start filter matching **multiple** nodes | ✅ | ❌ runtime `RAISE_ERROR` |
+| `is_terminator()` barriers, edge filters, sink filters | ✅ | ✅ |
+
+If procedural mode rejects your query, the error message says so
+explicitly — switch to `vlp_rendering_mode="cte"` (or drop the argument)
+and the query works.
+
+!!! note "Why a runtime guard?"
+    Whether a start filter matches one node or many is only known when the
+    query runs. The generated script counts the seed frontier and raises
+    `gsql2rsql procedural BFS is single-source but the start filter matched
+    multiple nodes` rather than fabricating unreachable (start, end) pairs.
+
+---
+
+## Schema Binding Errors
+
+Node labels and relationship types in your Cypher are matched against the
+registered schema **exactly** — case-sensitive, whitespace-sensitive. When
+a lookup misses, the error lists what is registered and flags
+case-insensitive near-matches:
+
+```text
+Failed to bind entity 'root' of type 'cnpj_raiz'. Did you mean 'CNPJ_RAIZ'?
+Node type names are matched exactly (case-sensitive, whitespace-sensitive).
+Available node types: 'CNPJ_RAIZ', 'socio'
+```
+
+```text
+Failed to bind relationship '_anon1' of type 'owns'. Did you mean 'OWNS'?
+Edge type names are matched exactly (case-sensitive, whitespace-sensitive).
+Available edge types: 'OWNS', 'PARTICIPA'
+```
+
+Two edge-type situations behave differently on purpose:
+
+- A type that exists for **no** endpoint pair anywhere in the schema is
+  treated as a typo and raises — including inside OR lists (`[:OWNS|KNOWS]`).
+- A type that exists but not between the pattern's endpoint node types is
+  silently dropped from an OR list. This is intentional: with restricted
+  `edge_combinations`, `[:X|Y]` between `A` nodes legitimately reduces to
+  `X` when `Y` only connects `A → B`.
+
+---
+
+## Parser Notes
+
+- **`!=` is rejected on purpose** — use `<>`. This avoids silent confusion
+  with other dialects; the parser error tells you the replacement.
+- **Backticks are fully supported** for labels, relationship types,
+  variables, property names, and aliases (`` (n:`my label`) ``,
+  ``RETURN n.`first name` AS x``). Doubled backticks escape a literal one.
+- **Unaliased projections get generated column names** derived from the
+  expression text: `RETURN count(DISTINCT d)` produces a column called
+  `count_DISTINCT_d`, `count(*)` produces `count_star`. Add `AS name` to
+  control the output column name.
+- **Multi-label syntax is not supported**: `(a:Person:Company)` silently
+  uses only the first label and `(a:Person|Company)` is a parser error.
+  Workaround: `WHERE a.node_type IN ['Person', 'Company']`.
+- **Standalone `UNWIND`** (a query with no `MATCH` clause) fails with
+  "Empty partial query". Add a `MATCH` or run plain SQL for constant data.
+- **Physical columns with spaces or special characters** (e.g. a column
+  literally named `first name`) are not supported end-to-end: the Cypher
+  side parses, but the generated SQL does not quote such columns. Table
+  *names* with backticks (`` `my-catalog`.schema.nodes ``) work fine —
+  they come from your schema configuration and are emitted verbatim.
+
+---
+
+## Correctness Caveats
+
+- **Aggregation after aggregation** (`WITH ... COUNT(...)` followed by
+  another aggregating `WITH`) has known edge cases that can surface as
+  Databricks `UNRESOLVED_COLUMN` at execution. Prefer flattening into a
+  single aggregation; explicitly alias every aggregated column.
+- **Self-loops in undirected patterns** (`(a)-[:KNOWS]-(a)`) may appear
+  twice in results due to the UNION ALL expansion.
+
+---
+
+## Performance Caveats
+
+### Deep Variable-Length Paths
+
+`WITH RECURSIVE` for deep traversals (`*1..20`) can be slow or hit Spark's
+recursion limits. Keep max depth ≤ 10 where possible, `LIMIT` your result
+sets, and when **both endpoints are filtered by ID**, use bidirectional
+BFS — its purpose is not speed but enabling queries that would otherwise
+exceed the recursion limit:
+
+```python
+sql = graph.transpile(query, bidirectional_mode="auto")
+```
+
+| Mode | Description |
+|---|---|
+| `"off"` | Standard unidirectional (default) |
+| `"recursive"` | Forward/backward recursive CTEs |
+| `"unrolling"` | Unrolled CTEs (better for depth ≤ 6) |
+| `"auto"` | Selects based on max hops |
+
+Restrictions: equality filters only, both endpoints filtered, single edge
+type.
+
+### Other
+
+- **`COLLECT()` over large groups** builds in-memory arrays — filter before
+  aggregating, or use `COUNT()` when only the size matters.
+- **Disconnected patterns** (`MATCH (p:Person), (c:Company)`) produce
+  cartesian products; always connect patterns through shared variables.
+- **`relationships(p)` is not free**: referencing it makes the recursive
+  CTE collect edge structs per path. Use `length(p)` when you only need
+  the hop count.
+
+---
+
+## Where to Go Next
+
+- [Getting Started](user-guide.md) — schema setup and first queries
+- [Functions Reference](functions.md) — supported openCypher functions
+- [Procedural BFS example](examples/procedural_bfs.md) — when and how to
+  use the procedural mode

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -509,13 +509,17 @@ sql = graph.transpile("""
 
 ## Limitations
 
+The most common ones:
+
 - **Databricks new Runtime** required for `WITH RECURSIVE` and HoF
-- **Write operations** not supported (`CREATE`, `DELETE`, `SET`)
-- **Multi-label node syntax** not yet supported:
-    - `(a:Person|Company)` - pipe OR syntax causes parser error
-    - `(a:Person:Company)` - colon AND syntax silently ignores additional labels
-    - **Workaround:** Use `WHERE a.node_type IN ['Person', 'Company']`
-- **Some Cypher features** not yet implemented
+- **Write operations** not supported (`CREATE`, `DELETE`, `SET`, `MERGE`)
+- **Multi-label node syntax** not yet supported — use
+  `WHERE a.node_type IN ['Person', 'Company']`
+- **Procedural BFS mode** is single-source and rejects `length(p)`,
+  `nodes(p)` and `*0..N` (CTE mode supports all of these)
+
+See the full **[Limitations](limitations.md)** page for the complete list,
+the CTE vs procedural feature matrix, and a guide to the error messages.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
   - User Guide:
     - Getting Started: user-guide.md
     - Functions Reference: functions.md
+    - Limitations: limitations.md
     - Examples:
       - examples/index.md
       - Fraud Detection: examples/fraud.md

--- a/src/gsql2rsql/parser/ast.py
+++ b/src/gsql2rsql/parser/ast.py
@@ -184,6 +184,9 @@ class QueryExpressionFunction(QueryExpression):
     function: Function
     parameters: list[QueryExpression] = field(default_factory=list)
     data_type: type[Any] | None = None
+    # The name as the user wrote it. Set for Function.INVALID so error
+    # messages can name the actual function instead of 'INVALID'.
+    raw_name: str = ""
 
     @property
     def children(self) -> list[TreeNode]:
@@ -212,12 +215,17 @@ class QueryExpressionAggregationFunction(QueryExpression):
     # Order by for ordered aggregation (e.g., COLLECT(x ORDER BY y DESC))
     # List of (expression, is_descending) tuples
     order_by: list[tuple[QueryExpression, bool]] = field(default_factory=list)
+    # Arguments beyond the aggregated expression, e.g. the percentile in
+    # percentileCont(x, 0.5). Kept separate from inner_expression because
+    # they parameterise the aggregate rather than being aggregated.
+    extra_parameters: list[QueryExpression] = field(default_factory=list)
 
     @property
     def children(self) -> list[TreeNode]:
         result: list[TreeNode] = []
         if self.inner_expression:
             result.append(self.inner_expression)
+        result.extend(self.extra_parameters)
         for expr, _ in self.order_by:
             result.append(expr)
         return result
@@ -228,6 +236,7 @@ class QueryExpressionAggregationFunction(QueryExpression):
     def __str__(self) -> str:
         distinct = "DISTINCT " if self.is_distinct else ""
         inner = str(self.inner_expression) if self.inner_expression else "*"
+        extras = "".join(f", {p}" for p in self.extra_parameters)
         order = ""
         if self.order_by:
             items = ", ".join(
@@ -235,7 +244,10 @@ class QueryExpressionAggregationFunction(QueryExpression):
                 for expr, desc in self.order_by
             )
             order = f" ORDER BY {items}"
-        return f"{self.aggregation_function.name}({distinct}{inner}{order})"
+        return (
+            f"{self.aggregation_function.name}"
+            f"({distinct}{inner}{extras}{order})"
+        )
 
 
 @dataclass

--- a/src/gsql2rsql/parser/visitor.py
+++ b/src/gsql2rsql/parser/visitor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 from gsql2rsql.common.exceptions import (
@@ -375,8 +376,15 @@ class CypherVisitor:
 
     def _apply_return_result(self, part: PartialQueryNode, result: dict[str, Any]) -> None:
         """Apply return clause results to a partial query node."""
-        if "body" in result:
-            part.return_body = result["body"]
+        body = result.get("body", [])
+        if result.get("star"):
+            # RETURN * / WITH * — openCypher: project every named variable
+            # in scope. Left unexpanded, the empty projection passed the
+            # renderer's internal `_gsql2rsql_*` columns (and anonymous
+            # edge plumbing) straight to the user.
+            body = self._expand_star_projections(part) + body
+        if body:
+            part.return_body = body
         if "distinct" in result:
             part.is_distinct = result["distinct"]
         if "order" in result:
@@ -385,6 +393,37 @@ class CypherVisitor:
             part.limit_clause = result["limit"]
         if "having" in result:
             part.having_expression = result["having"]
+
+    def _expand_star_projections(
+        self, part: PartialQueryNode
+    ) -> list[QueryExpressionWithAlias]:
+        """Expand ``*`` to the part's named variables, in declaration order.
+
+        Covers node/relationship aliases from MATCH patterns and UNWIND
+        variables. Unnamed entities (empty alias — the planner names those
+        ``_anonN`` later) are join plumbing, not user variables, and are
+        skipped. Named paths are also skipped: projecting a whole path is
+        not supported, and ``RETURN *`` must not fail a query whose path
+        variable is only consumed by relationships()/nodes().
+        """
+        aliases: list[str] = []
+        for match in part.match_clauses:
+            for entity in match.pattern_parts:
+                if entity.alias and entity.alias not in aliases:
+                    aliases.append(entity.alias)
+        for unwind in part.unwind_clauses:
+            if unwind.variable_name and unwind.variable_name not in aliases:
+                aliases.append(unwind.variable_name)
+
+        return [
+            QueryExpressionWithAlias(
+                inner_expression=QueryExpressionProperty(
+                    variable_name=alias, property_name=None
+                ),
+                alias=alias,
+            )
+            for alias in aliases
+        ]
 
     def _reject_updating_clauses(self, updating_clauses: list[Any]) -> None:
         """Reject write operations — this transpiler only supports read queries."""
@@ -724,7 +763,13 @@ class CypherVisitor:
         result["distinct"] = any(t.upper() == "DISTINCT" for t in text_children)
 
         if ctx.oC_ProjectionItems():
-            items = self.visit(ctx.oC_ProjectionItems())
+            items_ctx = ctx.oC_ProjectionItems()
+            # Grammar: ( '*' ( ',' item )* ) | ( item ( ',' item )* ).
+            # The star form has no ProjectionItem child of its own, so it
+            # must be flagged here and expanded once the enclosing part's
+            # variables are known (_apply_return_result).
+            result["star"] = items_ctx.getText().startswith("*")
+            items = self.visit(items_ctx)
             if isinstance(items, list):
                 result["body"] = items
 
@@ -786,11 +831,30 @@ class CypherVisitor:
     def visit_oC_ProjectionItems(self, ctx: Any) -> list[QueryExpressionWithAlias]:
         """Visit projection items context."""
         items: list[QueryExpressionWithAlias] = []
+        auto_derived: list[bool] = []
 
         for item_ctx in ctx.oC_ProjectionItem() or []:
             item = self.visit(item_ctx)
             if isinstance(item, QueryExpressionWithAlias):
                 items.append(item)
+                auto_derived.append(item_ctx.oC_Variable() is None)
+
+        # Unaliased projections derive their name from the property alone, so
+        # `RETURN a.name, b.name` collapses to two columns both called
+        # `name` — ambiguous for anything selecting by name downstream.
+        # Qualify auto-derived aliases with the variable when they collide;
+        # explicit `AS` aliases are the user's choice and are never touched.
+        alias_counts = Counter(item.alias for item in items)
+        for item, derived in zip(items, auto_derived):
+            if not derived or alias_counts[item.alias] <= 1:
+                continue
+            inner = item.inner_expression
+            if (
+                isinstance(inner, QueryExpressionProperty)
+                and inner.variable_name
+                and inner.property_name
+            ):
+                item.alias = f"{inner.variable_name}_{inner.property_name}"
 
         return items
 
@@ -1096,6 +1160,16 @@ class CypherVisitor:
                     result.property_name = prop_name
             elif rule_name == "OC_ListOperatorExpressionContext":
                 result = self._apply_list_operator(result, child)
+            elif rule_name == "OC_NodeLabelsContext":
+                # A label test in expression position (`WHERE a:Person`).
+                # Silently skipping it used to reduce the predicate to the
+                # bare variable, which rendered as a non-boolean WHERE on
+                # the id column — invalid SQL with no transpiler error.
+                raise TranspilerNotSupportedException(
+                    f"Label predicates in expressions are not supported: "
+                    f"'{ctx.getText()}'. Move the label into the pattern "
+                    f"instead, e.g. MATCH (x{child.getText()})."
+                )
 
         return result
 
@@ -1181,6 +1255,17 @@ class CypherVisitor:
     def visit_oC_PropertyOrLabelsExpression(self, ctx: Any) -> QueryExpression:
         """Visit a property or labels expression context."""
         result = self.visit(ctx.oC_Atom())
+
+        # A label test in expression position (`WHERE a:Person`). Silently
+        # ignoring it used to reduce the predicate to the bare variable,
+        # which rendered as a non-boolean WHERE on the id column.
+        if ctx.oC_NodeLabels():
+            labels = ctx.oC_NodeLabels().getText()
+            raise TranspilerNotSupportedException(
+                f"Label predicates in expressions are not supported: "
+                f"'{ctx.getText()}'. Move the label into the pattern "
+                f"instead, e.g. MATCH (x{labels})."
+            )
 
         # Handle property lookups
         for lookup_ctx in ctx.oC_PropertyLookup() or []:
@@ -1375,6 +1460,9 @@ class CypherVisitor:
                 is_distinct=is_distinct,
                 inner_expression=params[0] if params else None,
                 order_by=order_by,
+                # e.g. the percentile in percentileCont(x, 0.5) — dropping
+                # these silently changes the aggregate's meaning.
+                extra_parameters=params[1:],
             )
 
         # Check if it's a regular function
@@ -1385,10 +1473,12 @@ class CypherVisitor:
                 parameters=params,
             )
 
-        # Unknown function - return as generic function
+        # Unknown function — keep the user's spelling so the renderer's
+        # rejection can name it instead of the INVALID placeholder.
         return QueryExpressionFunction(
             function=Function.INVALID,
             parameters=params,
+            raw_name=func_name,
         )
 
     def visit_oC_ParenthesizedExpression(self, ctx: Any) -> QueryExpression:

--- a/src/gsql2rsql/planner/aggregation_boundary.py
+++ b/src/gsql2rsql/planner/aggregation_boundary.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from gsql2rsql.common.exceptions import TranspilerNotSupportedException
 from gsql2rsql.parser.ast import (
     MatchClause,
     NodeEntity,
@@ -44,10 +45,21 @@ from gsql2rsql.planner.operators import (
 
 
 def _extract_int_value(expr: QueryExpression | None) -> int | None:
-    """Safely extract integer value from a QueryExpressionValue."""
+    """Extract the integer from a literal SKIP/LIMIT expression.
+
+    Anything other than a literal (a ``$param``, an arithmetic expression)
+    must be rejected loudly: returning ``None`` here silently drops the
+    clause, so ``LIMIT $n`` used to return the entire result set.
+    """
+    if expr is None:
+        return None
     if isinstance(expr, QueryExpressionValue) and expr.value is not None:
         return int(expr.value)
-    return None
+    raise TranspilerNotSupportedException(
+        f"SKIP/LIMIT requires an integer literal; got '{expr}'. "
+        f"Parameters (e.g. LIMIT $n) are not supported — inline the value "
+        f"before transpiling."
+    )
 
 
 def part_creates_aggregation_boundary(

--- a/src/gsql2rsql/planner/match_tree.py
+++ b/src/gsql2rsql/planner/match_tree.py
@@ -55,10 +55,21 @@ from gsql2rsql.planner.operators import (
 
 
 def _extract_int_value(expr: QueryExpression | None) -> int | None:
-    """Safely extract integer value from a QueryExpressionValue."""
+    """Extract the integer from a literal SKIP/LIMIT expression.
+
+    Anything other than a literal (a ``$param``, an arithmetic expression)
+    must be rejected loudly: returning ``None`` here silently drops the
+    clause, so ``LIMIT $n`` used to return the entire result set.
+    """
+    if expr is None:
+        return None
     if isinstance(expr, QueryExpressionValue) and expr.value is not None:
         return int(expr.value)
-    return None
+    raise TranspilerNotSupportedException(
+        f"SKIP/LIMIT requires an integer literal; got '{expr}'. "
+        f"Parameters (e.g. LIMIT $n) are not supported — inline the value "
+        f"before transpiling."
+    )
 
 
 def _contains_is_terminator(expr: TreeNode) -> bool:
@@ -284,6 +295,22 @@ def create_standard_match_tree(
     for entity_idx, entity in enumerate(match_clause.pattern_parts):
         # Handle shared node variables
         if isinstance(entity, NodeEntity) and entity.alias in joined_node_aliases:
+            # No new data source: the node is already materialised. But the
+            # repetition still constrains the pattern — the preceding
+            # relationship's far endpoint must equal this node (self-loops
+            # `(a)-[:R]->(a)`, closed cycles `(a)->(b)->(a)`). Attach the
+            # SINK pair to the join that brought that relationship in;
+            # skipping it returns every path instead of every cycle.
+            if entity_idx > 0 and isinstance(current_op, JoinOperator):
+                prev_ent = match_clause.pattern_parts[entity_idx - 1]
+                if isinstance(prev_ent, RelationshipEntity):
+                    current_op.add_join_pair(
+                        JoinKeyPair(
+                            node_alias=entity.alias,
+                            relationship_or_node_alias=prev_ent.alias,
+                            pair_type=determine_sink_join_type(prev_ent),
+                        )
+                    )
             prev_node_alias = entity.alias
             continue
 

--- a/src/gsql2rsql/planner/operators/data_source.py
+++ b/src/gsql2rsql/planner/operators/data_source.py
@@ -67,6 +67,72 @@ def _describe_available_node_types(
     return f".{hint} Available node types: {', '.join(repr(n) for n in available)}"
 
 
+def _describe_available_edge_verbs(
+    graph_definition: IGraphSchemaProvider,
+    requested: str,
+) -> str:
+    """Build an actionable suffix for a failed edge-verb lookup.
+
+    Mirror of ``_describe_available_node_types``: verb lookup is exact and
+    case-sensitive, so a case difference or stray whitespace in the schema
+    registration is the overwhelmingly common cause.  Best-effort only —
+    providers that cannot enumerate their edges degrade to an empty suffix.
+    """
+    try:
+        get_all = getattr(graph_definition, "get_all_edge_schemas", None)
+        if get_all is None:
+            return ""
+        available = sorted({
+            schema.name for schema in get_all() if getattr(schema, "name", None)
+        })
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+    if not available:
+        return ""
+
+    near = [
+        name
+        for name in available
+        if name.strip().casefold() == requested.strip().casefold()
+    ]
+    hint = ""
+    if near:
+        hint = (
+            f" Did you mean '{near[0]}'? Edge type names are matched exactly "
+            f"(case-sensitive, whitespace-sensitive)."
+        )
+
+    return f".{hint} Available edge types: {', '.join(repr(n) for n in available)}"
+
+
+def validate_edge_verbs_exist(
+    raw_edge_types: list[str],
+    graph_definition: IGraphSchemaProvider,
+    rel_alias: str,
+) -> None:
+    """Raise if any named edge verb does not exist anywhere in the schema.
+
+    Distinguishes a typo (the verb is registered for NO endpoint pair —
+    raise with suggestions) from endpoint pruning (the verb exists but not
+    for the pattern's endpoint types — silently dropped by the caller,
+    which is load-bearing for schemas registered with restricted
+    ``edge_combinations``).
+
+    Called from both single-hop binding and the VLP planner so unknown
+    verbs fail at BINDING time, not as a late enrichment internal error.
+    """
+    from gsql2rsql.common.exceptions import TranspilerBindingException
+
+    for verb in raw_edge_types:
+        if not graph_definition.find_edges_by_verb(verb):
+            raise TranspilerBindingException(
+                f"Failed to bind relationship '{rel_alias}' "
+                f"of type '{verb}'"
+                + _describe_available_edge_verbs(graph_definition, verb)
+            )
+
+
 @dataclass
 class _BindingResult:
     """Result of binding an entity to a graph schema.
@@ -221,6 +287,12 @@ class DataSourceOperator(StartLogicalOperator, IBindable):
             t.strip() for t in rel_entity.entity_name.split("|") if t.strip()
         ]
 
+        # A verb that exists for NO endpoint pair is a typo — fail with
+        # suggestions before endpoint pruning silently drops it from an OR.
+        validate_edge_verbs_exist(
+            raw_edge_types, graph_definition, rel_entity.alias
+        )
+
         # Determine source/sink based on direction
         source_type, sink_type = self._get_endpoint_types(rel_entity)
 
@@ -238,7 +310,11 @@ class DataSourceOperator(StartLogicalOperator, IBindable):
             if not edge_def:
                 raise TranspilerBindingException(
                     f"Failed to bind relationship '{rel_entity.alias}' "
-                    f"of type '{rel_entity.entity_name}'"
+                    f"of type '{rel_entity.entity_name}': the type exists "
+                    f"but not between the pattern's endpoint node types"
+                    + _describe_available_edge_verbs(
+                        graph_definition, rel_entity.entity_name
+                    )
                 )
 
         # Build ID fields

--- a/src/gsql2rsql/planner/recursive_traversal.py
+++ b/src/gsql2rsql/planner/recursive_traversal.py
@@ -39,6 +39,7 @@ from gsql2rsql.planner.operators import (
     LogicalOperator,
     RecursiveTraversalOperator,
 )
+from gsql2rsql.planner.operators.data_source import validate_edge_verbs_exist
 from gsql2rsql.planner.path_analyzer import (
     PathExpressionAnalyzer,
     remove_pushed_predicates,
@@ -104,6 +105,13 @@ def create_recursive_match_tree(
         edge_types = [
             t.strip() for t in rel.entity_name.split("|") if t.strip()
         ]
+
+    # Unknown verbs must fail here, at binding time, with an actionable
+    # message. Without this, the wildcard fallback below silently absorbs
+    # the typo and the enrichment pass later dies with a cryptic
+    # "No enriched data for RecursiveTraversalOperator" internal error.
+    if graph_schema is not None and edge_types:
+        validate_edge_verbs_exist(edge_types, graph_schema, rel.alias)
 
     # Extract source node filter from WHERE clause for optimization
     start_node_filter, remaining_where = extract_source_node_filter(

--- a/src/gsql2rsql/renderer/dialect.py
+++ b/src/gsql2rsql/renderer/dialect.py
@@ -113,6 +113,13 @@ AGGREGATION_PATTERNS: dict[AggregationFunction, str] = {
     AggregationFunction.STDEVP: "STDDEV_POP({0})",
     AggregationFunction.COUNT: "COUNT({0})",
     AggregationFunction.COLLECT: "COLLECT_LIST({0})",
+    # {1} is the percentile argument (percentileCont(x, 0.5) -> 0.5).
+    AggregationFunction.PERCENTILE_CONT: (
+        "PERCENTILE_CONT({1}) WITHIN GROUP (ORDER BY {0})"
+    ),
+    AggregationFunction.PERCENTILE_DISC: (
+        "PERCENTILE_DISC({1}) WITHIN GROUP (ORDER BY {0})"
+    ),
 }
 
 

--- a/src/gsql2rsql/renderer/expression_renderer.py
+++ b/src/gsql2rsql/renderer/expression_renderer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from gsql2rsql.common.exceptions import (
     TranspilerInternalErrorException,
     TranspilerNotSupportedException,
+    TranspilerSyntaxErrorException,
 )
 from gsql2rsql.parser.ast import (
     NodeEntity,
@@ -50,7 +51,7 @@ from gsql2rsql.renderer.dialect import (
     render_from_template,
 )
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from gsql2rsql.renderer.render_context import RenderContext
@@ -287,8 +288,25 @@ class ExpressionRenderer:
         right = self.render_expression(expr.right_expression, context_op)
 
         # String concatenation: Cypher + on strings → Spark CONCAT()
+        # List concatenation: Cypher + on lists → Spark CONCAT() too; Spark
+        # has no `+` overload for arrays, so falling through to arithmetic
+        # `+` was a DATATYPE_MISMATCH error at execution time.
         if expr.operator.name == BinaryOperator.PLUS:
-            if self._is_string_concat(expr.left_expression, expr.right_expression):
+            if self._is_array_concat(
+                expr.left_expression, expr.right_expression, context_op
+            ):
+                # List literals render as `(a, b)` for IN clauses; as a
+                # CONCAT operand they must be a real ARRAY value.
+                left = self._render_as_array_value(
+                    expr.left_expression, context_op
+                )
+                right = self._render_as_array_value(
+                    expr.right_expression, context_op
+                )
+                return f"CONCAT({left}, {right})"
+            if self._is_string_concat(
+                expr.left_expression, expr.right_expression, context_op
+            ):
                 return f"CONCAT({left}, {right})"
 
         # Special handling for timestamp subtraction in Databricks SQL
@@ -309,17 +327,97 @@ class ExpressionRenderer:
         return pattern.format(left, right)
 
     def _is_string_concat(
-        self, left: QueryExpression, right: QueryExpression
+        self,
+        left: QueryExpression,
+        right: QueryExpression,
+        context_op: LogicalOperator | None = None,
     ) -> bool:
         """Check if a + operation is string concatenation (not numeric)."""
-        return self._has_string_type(left) or self._has_string_type(right)
+        return self._has_string_type(left, context_op) or self._has_string_type(
+            right, context_op
+        )
 
-    def _has_string_type(self, expr: QueryExpression) -> bool:
+    def _is_array_concat(
+        self,
+        left: QueryExpression,
+        right: QueryExpression,
+        context_op: LogicalOperator | None = None,
+    ) -> bool:
+        """Check if a + operation is list concatenation (not numeric)."""
+        return self._has_array_type(left, context_op) or self._has_array_type(
+            right, context_op
+        )
+
+    def _has_array_type(
+        self,
+        expr: QueryExpression,
+        context_op: LogicalOperator | None = None,
+    ) -> bool:
+        """Check if an expression is list-typed (literal or schema type)."""
+        if isinstance(expr, QueryExpressionList):
+            return True
+        if expr.evaluate_type() is list:
+            return True
+        return self._schema_property_type(expr, context_op) is list
+
+    def _schema_property_type(
+        self,
+        expr: QueryExpression,
+        context_op: LogicalOperator | None,
+    ) -> type[Any] | None:
+        """Look up a property's declared type in the operator's schema.
+
+        AST nodes often reach the renderer with ``data_type`` unset, so
+        ``evaluate_type()`` alone cannot drive type dispatch (Cypher
+        ``size()``/``+`` are polymorphic). The operator's input schema is
+        the planner's authoritative view: entity fields carry each
+        property's declared Python type from the graph schema.
+        """
+        if (
+            context_op is None
+            or not isinstance(expr, QueryExpressionProperty)
+            or not expr.property_name
+        ):
+            return None
+        schema = getattr(context_op, "input_schema", None)
+        if not schema:
+            return None
+        entity = schema.get_field(expr.variable_name)
+        if isinstance(entity, EntityField):
+            for value_field in entity.encapsulated_fields:
+                if value_field.field_alias == expr.property_name:
+                    return value_field.data_type
+        return None
+
+    def _render_as_array_value(
+        self, expr: QueryExpression, context_op: LogicalOperator
+    ) -> str:
+        """Render an expression as an ARRAY *value*.
+
+        ``_render_list`` emits ``(a, b)`` because its main consumer is SQL
+        ``IN`` lists; contexts that need a first-class array (CONCAT
+        operands) must wrap the elements in ``ARRAY(...)`` instead.
+        """
+        if isinstance(expr, QueryExpressionList):
+            items = [
+                self.render_expression(item, context_op)
+                for item in expr.items
+            ]
+            return f"ARRAY({', '.join(items)})"
+        return self.render_expression(expr, context_op)
+
+    def _has_string_type(
+        self,
+        expr: QueryExpression,
+        context_op: LogicalOperator | None = None,
+    ) -> bool:
         """Check if an expression is string-typed (recursively for + chains)."""
         expr_type = expr.evaluate_type()
         if expr_type is str:
             return True
         if isinstance(expr, QueryExpressionValue) and isinstance(expr.value, str):
+            return True
+        if self._schema_property_type(expr, context_op) is str:
             return True
         # Recurse into + chains: if (a + 'x') is the left operand,
         # the inner 'x' makes the whole chain string concatenation
@@ -327,9 +425,9 @@ class ExpressionRenderer:
             if expr.operator and expr.operator.name == BinaryOperator.PLUS:
                 left = expr.left_expression
                 right = expr.right_expression
-                if left and self._has_string_type(left):
+                if left and self._has_string_type(left, context_op):
                     return True
-                if right and self._has_string_type(right):
+                if right and self._has_string_type(right, context_op):
                     return True
         return False
 
@@ -457,6 +555,17 @@ class ExpressionRenderer:
 
         func = expr.function
 
+        # Cypher size() is polymorphic: element count for lists/maps,
+        # character count for strings. Spark's SIZE() is array/map-only, so
+        # a string operand must become LENGTH() — the blanket template used
+        # to emit SIZE(<string>), a type error at execution time.
+        if (
+            func == Function.SIZE
+            and expr.parameters
+            and self._has_string_type(expr.parameters[0], context_op)
+        ):
+            return f"LENGTH({params[0]})"
+
         # --- Data-driven dispatch for simple functions ---
         tmpl = FUNCTION_TEMPLATES.get(func)
         if tmpl is not None:
@@ -549,9 +658,15 @@ class ExpressionRenderer:
                     return self._parse_iso8601_duration(rendered[1:-1])
             return "INTERVAL '0' DAY"
         else:
-            raise NotImplementedError(
-                f"_render_function: unsupported function {func!r}. "
-                f"Add to FUNCTION_TEMPLATES in dialect.py or add an explicit handler."
+            # Library error, never NotImplementedError: this is reachable by
+            # any user query calling a function without a translation, and
+            # the message must name what they wrote (raw_name), not the
+            # parser's INVALID placeholder.
+            user_name = expr.raw_name or func.name.lower()
+            raise TranspilerNotSupportedException(
+                f"Function '{user_name}()' is not supported by the "
+                f"transpiler. See docs/limitations.md for the list of "
+                f"supported functions and workarounds."
             )
 
     def _render_aggregation(
@@ -601,8 +716,27 @@ class ExpressionRenderer:
         if expr.is_distinct:
             inner = f"DISTINCT {inner}"
 
-        pattern = AGGREGATION_PATTERNS.get(expr.aggregation_function, "{0}")
-        return pattern.format(inner)
+        pattern = AGGREGATION_PATTERNS.get(expr.aggregation_function)
+        if pattern is None:
+            # A silent "{0}" fallback here once emitted the bare operand for
+            # percentileCont(), turning an aggregate into a per-row
+            # projection — a wrong answer with no warning. Fail loudly.
+            raise TranspilerNotSupportedException(
+                f"Aggregation function "
+                f"'{expr.aggregation_function.name.lower()}' has no SQL "
+                f"translation. Add it to AGGREGATION_PATTERNS in dialect.py."
+            )
+
+        extras = [
+            self.render_expression(p, context_op)
+            for p in expr.extra_parameters
+        ]
+        if "{1}" in pattern and not extras:
+            raise TranspilerSyntaxErrorException(
+                f"{expr.aggregation_function.name.lower()} requires a "
+                f"second argument (e.g. percentileCont(expr, 0.5))."
+            )
+        return pattern.format(inner, *extras)
 
     def _render_ordered_collect(
         self, expr: QueryExpressionAggregationFunction, context_op: LogicalOperator
@@ -1275,9 +1409,9 @@ class ExpressionRenderer:
         tmpl = FUNCTION_TEMPLATES.get(func)
         if tmpl is not None:
             return render_from_template(tmpl, params)
-        raise NotImplementedError(
-            f"_render_function_with_params: unsupported function {func!r}. "
-            f"Add to FUNCTION_TEMPLATES in dialect.py or add an explicit handler."
+        raise TranspilerNotSupportedException(
+            f"Function '{func.name.lower()}()' is not supported inside "
+            f"list predicates. See docs/limitations.md."
         )
 
     def _render_exists(
@@ -1710,9 +1844,10 @@ class ExpressionRenderer:
             if tmpl is not None:
                 return render_from_template(tmpl, params)
 
-            raise NotImplementedError(
-                f"render_edge_filter_expression: unsupported function {func!r}. "
-                f"Add to FUNCTION_TEMPLATES in dialect.py or add an explicit handler."
+            raise TranspilerNotSupportedException(
+                f"Function '{func.name.lower()}()' is not supported inside "
+                f"a variable-length path edge filter. See "
+                f"docs/limitations.md."
             )
 
         elif isinstance(expr, QueryExpressionValue):

--- a/src/gsql2rsql/renderer/schema_provider.py
+++ b/src/gsql2rsql/renderer/schema_provider.py
@@ -399,6 +399,10 @@ class SimpleSQLSchemaProvider(ISQLDBSchemaProvider):
         """Get all registered node schemas."""
         return list(self._nodes.values())
 
+    def get_all_edge_schemas(self) -> list[EdgeSchema]:
+        """Get all registered edge schemas."""
+        return list(self._edges.values())
+
     def get_edge_definition(
         self, edge_verb: str, from_node_name: str, to_node_name: str
     ) -> EdgeSchema | None:

--- a/src/gsql2rsql/renderer/schema_provider.py
+++ b/src/gsql2rsql/renderer/schema_provider.py
@@ -239,8 +239,6 @@ class SimpleSQLSchemaProvider(ISQLDBSchemaProvider):
 
         The first edge added is used as the base for untyped edge support.
         """
-        self._edges[schema.id] = schema
-
         # Create default table descriptor if not provided
         if table_descriptor is None:
             table_descriptor = SQLTableDescriptor(
@@ -249,6 +247,28 @@ class SimpleSQLSchemaProvider(ISQLDBSchemaProvider):
                 node_id_columns=["source_id", "target_id"],
             )
 
+        # An edge without id properties cannot be joined: the renderer would
+        # prune the (undeclared) key columns out of the edge subquery while
+        # still naming them in the ON clause — SQL that cannot execute.
+        # Derive them from the descriptor's [source, sink] columns; reject
+        # when even that is impossible.
+        if schema.source_id_property is None or schema.sink_id_property is None:
+            columns = table_descriptor.node_id_columns or []
+            if len(columns) < 2:
+                raise ValueError(
+                    f"Edge '{schema.name}' has no source_id_property/"
+                    f"sink_id_property and its table descriptor declares "
+                    f"{len(columns)} node_id_columns — the join keys cannot "
+                    f"be determined. Provide both id properties on the "
+                    f"EdgeSchema or two node_id_columns ([source, sink]) on "
+                    f"the SQLTableDescriptor."
+                )
+            if schema.source_id_property is None:
+                schema.source_id_property = EntityProperty(columns[0], int)
+            if schema.sink_id_property is None:
+                schema.sink_id_property = EntityProperty(columns[1], int)
+
+        self._edges[schema.id] = schema
         self._table_descriptors[schema.id] = table_descriptor
         # Auto-detect base edge table from first edge added
         if self._base_edge_table is None:

--- a/tests/pyspark_tests/test_aggregation_boundary_pyspark.py
+++ b/tests/pyspark_tests/test_aggregation_boundary_pyspark.py
@@ -1,0 +1,299 @@
+"""Execution coverage for the aggregation-boundary code path.
+
+``WITH <entity>, <aggregate> ... MATCH (<entity>)-[...]->(...)`` creates an
+``AggregationBoundaryOperator`` plus a CTE that is joined back on the grouped
+entity's id.  It is the densest bug area in this project's history --
+``155da2f`` (preserve full column names for entity projections after
+aggregation), ``6388679`` (use the AggregationBoundaryOperator itself),
+``7ec0add`` (multi-WITH entity continuation) -- and
+``docs_help_dev/limitations.md`` still lists "Aggregation After Aggregation" as
+*Under Investigation*.
+
+Existing coverage (``test_44_match_after_aggregating_with.py``,
+``test_41_column_projection_through_aggregation.py``,
+``test_aggregation_entity_projection.py``) is **S-level only**: substring
+assertions on the SQL.  Nothing executes this path.  These tests do.
+
+Fixture A -- ``payments`` (see test_business_composite_pyspark.py for the full
+diagram)::
+
+                   (frozen)
+    A1 ──────► A2 ──────► A3 ──────► A4
+    │          ▲                      │
+    │          │                      ▼
+    └────────► A5 ──────► A6         A7  (leaf)
+                           │
+                           └──► A6   (self-loop)
+
+    A8 (isolated)   A9 (NULL risk_score)
+
+Out-degrees: A1=2, A2=1, A3=1, A4=1, A5=2, A6=1, A7=0, A8=0, A9=0.
+"""
+
+import pytest
+
+from tests.utils.spark_session import new_test_session
+
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Isolated child session. Never call spark.stop() -- see tests/utils."""
+    session = new_test_session()
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW ab_nodes AS
+        SELECT * FROM VALUES
+            ('A1', 'Account', 90,   'active', 'Lisboa'),
+            ('A2', 'Account', 20,   'frozen', 'Lisboa'),
+            ('A3', 'Account', 55,   'active', 'Porto'),
+            ('A4', 'Account', 70,   'active', 'Porto'),
+            ('A5', 'Account', 40,   'active', 'Lisboa'),
+            ('A6', 'Account', 85,   'active', 'Porto'),
+            ('A7', 'Account', 30,   'active', 'Braga'),
+            ('A8', 'Account', 10,   'active', 'Braga'),
+            ('A9', 'Account', CAST(NULL AS INT), 'active', 'Lisboa')
+        AS t(node_id, node_type, risk_score, status, city)
+    """)
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW ab_edges AS
+        SELECT * FROM VALUES
+            ('A1', 'A2', 'TRANSFER', 1000),
+            ('A1', 'A5', 'TRANSFER',  500),
+            ('A2', 'A3', 'TRANSFER', 2000),
+            ('A3', 'A4', 'TRANSFER',  300),
+            ('A4', 'A7', 'TRANSFER',  750),
+            ('A5', 'A2', 'TRANSFER',  600),
+            ('A5', 'A6', 'TRANSFER',  900),
+            ('A6', 'A6', 'TRANSFER',  250)
+        AS t(src, dst, relationship_type, amount)
+    """)
+    return session
+
+
+@pytest.fixture(scope="module")
+def graph(spark):
+    from gsql2rsql import GraphContext
+
+    ctx = GraphContext(
+        spark=spark,
+        nodes_table="ab_nodes",
+        edges_table="ab_edges",
+        node_id_col="node_id",
+        node_type_col="node_type",
+        edge_type_col="relationship_type",
+        edge_src_col="src",
+        edge_dst_col="dst",
+        extra_node_attrs={"risk_score": int, "status": str, "city": str},
+        extra_edge_attrs={"amount": int},
+    )
+    ctx.set_types(node_types=["Account"], edge_types=["TRANSFER"])
+    return ctx
+
+
+class TestMatchAfterAggregatingWith:
+    """Aggregate, filter on the aggregate, then traverse from the entity."""
+
+    def test_rebind_entity_and_traverse_again(self, spark, graph):
+        """Out-degree >= 2, then re-traverse from the surviving accounts.
+
+        Out-degrees: A1=2, A2=1, A3=1, A4=1, A5=2, A6=1.
+        ``out_degree >= 2`` keeps {A1, A5}.
+        Re-matching their outgoing transfers counts 2 each.
+
+        ``city`` in the projection proves entity *properties* still resolve
+        after the aggregation boundary -- the exact failure mode of ``155da2f``.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(b:Account)
+        WITH a, COUNT(b) AS out_degree
+        WHERE out_degree >= 2
+        MATCH (a)-[:TRANSFER]->(x:Account)
+        RETURN a.node_id AS id, a.city AS city, COUNT(x) AS transfers
+        ORDER BY id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["id"], r["city"], r["transfers"]) for r in rows]
+        assert results == [("A1", "Lisboa", 2), ("A5", "Lisboa", 2)], (
+            f"Expected [('A1','Lisboa',2), ('A5','Lisboa',2)], got {results}"
+        )
+
+    def test_aggregate_value_survives_the_boundary(self, spark, graph):
+        """The aggregate computed *before* the boundary is still readable.
+
+        ``out_degree`` is projected in the final RETURN, after a second MATCH
+        has joined new rows in.  It must keep its pre-boundary value (2), not
+        be recomputed against the new row count.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(b:Account)
+        WITH a, COUNT(b) AS out_degree
+        WHERE out_degree >= 2
+        MATCH (a)-[:TRANSFER]->(x:Account)
+        RETURN a.node_id AS id, out_degree, x.node_id AS target
+        ORDER BY id, target
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["id"], r["out_degree"], r["target"]) for r in rows]
+        assert results == [
+            ("A1", 2, "A2"),
+            ("A1", 2, "A5"),
+            ("A5", 2, "A2"),
+            ("A5", 2, "A6"),
+        ], f"Expected 4 rows with out_degree 2 throughout, got {results}"
+
+
+class TestAggregationAfterAggregation:
+    """The pattern ``limitations.md`` lists as 'Under Investigation'."""
+
+    def test_group_then_regroup(self, spark, graph):
+        """Count per account, then sum those counts per city.
+
+        Per-sender out-degrees: A1=2, A2=1, A3=1, A4=1, A5=2, A6=1.
+        Grouped by city:
+          Lisboa {A1:2, A2:1, A5:2} -> 5
+          Porto  {A3:1, A4:1, A6:1} -> 3
+        Braga has no senders and is absent.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(b:Account)
+        WITH a, COUNT(b) AS out_degree
+        WITH a.city AS city, SUM(out_degree) AS total_transfers
+        RETURN city, total_transfers
+        ORDER BY city
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["city"], r["total_transfers"]) for r in rows]
+        assert results == [("Lisboa", 5), ("Porto", 3)], (
+            f"Expected [('Lisboa', 5), ('Porto', 3)], got {results}"
+        )
+
+
+class TestOptionalMatchCounting:
+    """``COUNT(x)`` vs ``COUNT(*)`` across a LEFT JOIN."""
+
+    def test_isolated_nodes_count_zero_not_one(self, spark, graph):
+        """Every account appears; senders count their edges, others count 0.
+
+        A7 (leaf), A8 (isolated) and A9 have no outgoing transfers.  They must
+        appear with ``COUNT(b) = 0`` -- not be dropped (that would be an INNER
+        JOIN) and not be 1 (that would be counting the NULL-padded row).
+        """
+        query = """
+        MATCH (a:Account)
+        OPTIONAL MATCH (a)-[:TRANSFER]->(b:Account)
+        RETURN a.node_id AS id, COUNT(b) AS out_deg
+        ORDER BY id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["id"], r["out_deg"]) for r in rows]
+        assert results == [
+            ("A1", 2), ("A2", 1), ("A3", 1), ("A4", 1), ("A5", 2),
+            ("A6", 1), ("A7", 0), ("A8", 0), ("A9", 0),
+        ], f"Expected all 9 accounts with A7/A8/A9 at 0, got {results}"
+
+    def test_count_star_counts_the_padded_row(self, spark, graph):
+        """``COUNT(*)`` counts rows, so an unmatched left row still counts 1.
+
+        This is the classic divergence: for A7/A8/A9, ``COUNT(b)`` is 0 but
+        ``COUNT(*)`` is 1, because the LEFT JOIN produced one NULL-padded row.
+        """
+        query = """
+        MATCH (a:Account)
+        OPTIONAL MATCH (a)-[:TRANSFER]->(b:Account)
+        RETURN a.node_id AS id, COUNT(b) AS matched, COUNT(*) AS rows_out
+        ORDER BY id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        by_id = {r["id"]: (r["matched"], r["rows_out"]) for r in rows}
+        assert by_id["A7"] == (0, 1), f"A7: {by_id['A7']}"
+        assert by_id["A8"] == (0, 1), f"A8: {by_id['A8']}"
+        assert by_id["A1"] == (2, 2), f"A1: {by_id['A1']}"
+
+
+class TestAggregateCoverage:
+    """Aggregates with templates but no query-level test."""
+
+    def test_min_max_over_nullable_column(self, spark, graph):
+        """MIN/MAX skip NULL: A9's NULL risk_score must not become the MIN.
+
+        risk_scores: 90, 20, 55, 70, 40, 85, 30, 10, NULL.
+        MIN = 10 (A8), MAX = 90 (A1), COUNT = 8 non-NULL of 9 accounts.
+        """
+        query = """
+        MATCH (a:Account)
+        RETURN MIN(a.risk_score) AS lo, MAX(a.risk_score) AS hi,
+               COUNT(a.risk_score) AS scored, COUNT(*) AS total
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        assert len(rows) == 1
+        row = rows[0]
+        assert (row["lo"], row["hi"]) == (10, 90), (row["lo"], row["hi"])
+        assert row["scored"] == 8, row["scored"]
+        assert row["total"] == 9, row["total"]
+
+    def test_stdevp_over_known_population(self, spark, graph):
+        """``stDevP`` renders to STDDEV_POP and computes over non-NULL values.
+
+        Non-NULL scores: 90, 20, 55, 70, 40, 85, 30, 10 -- mean 50.0.
+        Population standard deviation (``statistics.pstdev``) = 27.9508...,
+        which distinguishes ``stDevP`` from ``stDev`` (the *sample* stdev of
+        the same values is 29.8807).  Asserted to a tolerance rather than a
+        decimal expansion.
+        """
+        query = """
+        MATCH (a:Account)
+        RETURN stDevP(a.risk_score) AS spread, AVG(a.risk_score) AS mean
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        assert len(rows) == 1
+        # (90+20+55+70+40+85+30+10)/8 = 50.0
+        assert float(rows[0]["mean"]) == pytest.approx(50.0, abs=0.01)
+        assert float(rows[0]["spread"]) == pytest.approx(27.951, abs=0.01)
+
+    def test_percentile_cont_median(self, spark, graph):
+        """``percentileCont`` must aggregate, not return one row per account.
+
+        Non-NULL scores sorted: 10, 20, 30, 40, 55, 70, 85, 90.
+        Continuous median = (40 + 55) / 2 = 47.5.
+
+        EXPECTED TO FAIL -- ``percentileCont`` has no entry in
+        ``AGGREGATION_TEMPLATES``, so the renderer emits the bare operand and
+        this returns 9 rows of raw scores.  See
+        ``tests/test_unsupported_aggregations.py`` for the structural
+        counterpart and the root cause.
+        """
+        query = """
+        MATCH (a:Account)
+        RETURN percentileCont(a.risk_score, 0.5) AS median
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        assert len(rows) == 1, (
+            f"percentileCont must produce a single aggregate row, got "
+            f"{len(rows)} rows: {[r.asDict() for r in rows]}"
+        )
+        assert float(rows[0]["median"]) == pytest.approx(47.5, abs=0.01)

--- a/tests/pyspark_tests/test_business_composite_pyspark.py
+++ b/tests/pyspark_tests/test_business_composite_pyspark.py
@@ -1,0 +1,292 @@
+"""Business-shaped composite queries: pattern + filter + traversal + aggregation.
+
+These are the queries a fraud/credit analyst actually writes.  Each combines
+several features whose *interaction* is the risk -- single-feature coverage
+already exists for all of them individually.
+
+Fixture A -- ``payments``::
+
+                   (frozen)
+    A1 ──────► A2 ──────► A3 ──────► A4
+    │          ▲                      │
+    │          │                      ▼
+    └────────► A5 ──────► A6         A7  (leaf, no outgoing edges)
+                           │
+                           └──► A6   (SELF-LOOP)
+
+    A8  (isolated -- no edges at all)
+    A9  (NULL risk_score, no edges)
+
+    id  risk_score  status   city
+    A1      90      active   Lisboa
+    A2      20      frozen   Lisboa      <- barrier node
+    A3      55      active   Porto
+    A4      70      active   Porto
+    A5      40      active   Lisboa
+    A6      85      active   Porto       <- self-loop
+    A7      30      active   Braga       <- leaf
+    A8      10      active   Braga       <- isolated
+    A9    NULL      active   Lisboa      <- NULL property
+
+    edges (TRANSFER, amount):
+    A1->A2 1000, A1->A5 500, A2->A3 2000, A3->A4 300,
+    A4->A7 750,  A5->A2 600, A5->A6 900, A6->A6 250
+
+Every node and edge is load-bearing: A2 is the frozen barrier, A6 the
+self-loop, A7 the leaf, A8 the isolated node (zero-count under LEFT JOIN),
+A9 the NULL property, and A1's two routes to A2 (direct and via A5) make
+route-counting non-trivial.
+"""
+
+import pytest
+
+from tests.utils.spark_session import new_test_session
+
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Isolated child session. Never call spark.stop() -- see tests/utils."""
+    session = new_test_session()
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW bc_nodes AS
+        SELECT * FROM VALUES
+            ('A1', 'Account', 90,   'active', 'Lisboa'),
+            ('A2', 'Account', 20,   'frozen', 'Lisboa'),
+            ('A3', 'Account', 55,   'active', 'Porto'),
+            ('A4', 'Account', 70,   'active', 'Porto'),
+            ('A5', 'Account', 40,   'active', 'Lisboa'),
+            ('A6', 'Account', 85,   'active', 'Porto'),
+            ('A7', 'Account', 30,   'active', 'Braga'),
+            ('A8', 'Account', 10,   'active', 'Braga'),
+            ('A9', 'Account', CAST(NULL AS INT), 'active', 'Lisboa')
+        AS t(node_id, node_type, risk_score, status, city)
+    """)
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW bc_edges AS
+        SELECT * FROM VALUES
+            ('A1', 'A2', 'TRANSFER', 1000),
+            ('A1', 'A5', 'TRANSFER',  500),
+            ('A2', 'A3', 'TRANSFER', 2000),
+            ('A3', 'A4', 'TRANSFER',  300),
+            ('A4', 'A7', 'TRANSFER',  750),
+            ('A5', 'A2', 'TRANSFER',  600),
+            ('A5', 'A6', 'TRANSFER',  900),
+            ('A6', 'A6', 'TRANSFER',  250)
+        AS t(src, dst, relationship_type, amount)
+    """)
+    return session
+
+
+@pytest.fixture(scope="module")
+def graph(spark):
+    from gsql2rsql import GraphContext
+
+    ctx = GraphContext(
+        spark=spark,
+        nodes_table="bc_nodes",
+        edges_table="bc_edges",
+        node_id_col="node_id",
+        node_type_col="node_type",
+        edge_type_col="relationship_type",
+        edge_src_col="src",
+        edge_dst_col="dst",
+        extra_node_attrs={"risk_score": int, "status": str, "city": str},
+        extra_edge_attrs={"amount": int},
+    )
+    ctx.set_types(node_types=["Account"], edge_types=["TRANSFER"])
+    return ctx
+
+
+class TestLaunderingRouteAnalysis:
+    """VLP + node barrier + sink filter + aggregation + ordering."""
+
+    def test_risky_accounts_reachable_avoiding_frozen(self, spark, graph):
+        """"Which risky accounts are reachable from A1 within 3 hops without
+        routing through a frozen account, and by how many routes?"
+
+        Traversal from A1 with every path node required to be non-frozen:
+          * A1 -> A2  blocked immediately (A2 is frozen)
+          * A1 -> A5              (1 hop)
+          * A1 -> A5 -> A2        blocked (A2 frozen)
+          * A1 -> A5 -> A6        (2 hops)
+          * A1 -> A5 -> A6 -> A6  (3 hops, traversing the self-loop once)
+
+        Reachable, non-frozen: {A5, A6}.
+        Sink filter risk_score > 50: A5 is 40 (fails), A6 is 85 (passes).
+
+        A6 is therefore reached by TWO distinct paths -- the self-loop is a
+        legitimate third hop, used once, so relationship uniqueness does not
+        exclude it and the cycle guard (which tracks the edge *source*) does
+        not either.  Verified by projecting nodes(p):
+        ``['A1','A5','A6']`` and ``['A1','A5','A6','A6']``.
+
+        Expected: exactly one row, (A6, 2 routes).
+        """
+        query = """
+        MATCH p = (src:Account)-[:TRANSFER*1..3]->(dst:Account)
+        WHERE src.node_id = 'A1'
+          AND dst.risk_score > 50
+          AND ALL(n IN nodes(p) WHERE n.status <> 'frozen')
+        RETURN dst.node_id AS id, COUNT(*) AS routes
+        ORDER BY id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["id"], r["routes"]) for r in rows]
+        assert results == [("A6", 2)], (
+            f"Expected [('A6', 2)], got {results}. A6 is the only account "
+            f"with risk_score > 50 reachable from A1 without passing through "
+            f"the frozen account A2, and it is reached by two paths."
+        )
+
+    def test_without_barrier_frozen_route_opens_up(self, spark, graph):
+        """Control: drop the barrier and the A2 route becomes available.
+
+        Without the ``status <> 'frozen'`` guard, from A1 within 3 hops:
+          A2 (1), A5 (1), A3 (2 via A2), A6 (2 via A5), A4 (3 via A2->A3),
+          A2 again (2, via A5).
+        With risk_score > 50: A3 (55), A4 (70), A6 (85).
+
+        Proves the barrier in the previous test does real work rather than
+        the result being empty for an unrelated reason.
+        """
+        query = """
+        MATCH p = (src:Account)-[:TRANSFER*1..3]->(dst:Account)
+        WHERE src.node_id = 'A1' AND dst.risk_score > 50
+        RETURN DISTINCT dst.node_id AS id
+        ORDER BY id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [r["id"] for r in rows]
+        assert results == ["A3", "A4", "A6"], (
+            f"Expected ['A3', 'A4', 'A6'], got {results}"
+        )
+
+
+class TestCityRiskConcentration:
+    """Aggregation + HAVING + ordering + expression in the projection."""
+
+    def test_cities_by_average_risk_of_senders(self, spark, graph):
+        """"Which cities host >= 2 accounts that send money, ranked by the
+        average risk carried per outgoing transfer?"
+
+        One row is produced per outgoing TRANSFER, so an account that sends
+        twice contributes twice to ``AVG`` while ``COUNT(DISTINCT)`` counts it
+        once.  That asymmetry is correct openCypher and is the point of the
+        test: ``DISTINCT`` inside one aggregate must not silently dedupe the
+        rows feeding the others.
+
+        Outgoing transfers by city:
+          Lisboa: A1->A2 (90), A1->A5 (90), A2->A3 (20), A5->A2 (40),
+                  A5->A6 (40)                      -> 5 rows, 3 distinct senders
+          Porto:  A3->A4 (55), A4->A7 (70), A6->A6 (85)
+                                                   -> 3 rows, 3 distinct senders
+          Braga:  none (A7 is a leaf, A8 isolated)  -> absent
+
+        avg_risk: Lisboa (90+90+20+40+40)/5 = 56.0, Porto (55+70+85)/3 = 70.0.
+        Both cities pass ``senders >= 2``.  Ordered DESC: Porto, Lisboa.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(:Account)
+        WITH a.city AS city, COUNT(DISTINCT a.node_id) AS senders,
+             AVG(a.risk_score) AS avg_risk
+        WHERE senders >= 2
+        RETURN city, senders, avg_risk
+        ORDER BY avg_risk DESC
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [
+            (r["city"], r["senders"], round(float(r["avg_risk"]), 1))
+            for r in rows
+        ]
+        assert results == [("Porto", 3, 70.0), ("Lisboa", 3, 56.0)], (
+            f"Expected [('Porto', 3, 70.0), ('Lisboa', 3, 56.0)], got "
+            f"{results}. Lisboa's 56.0 (not 50.0) is correct: A1 and A5 each "
+            f"send twice, so they weight AVG twice while COUNT(DISTINCT) "
+            f"counts them once."
+        )
+
+
+class TestSharedCounterparty:
+    """Self-join on one label + cross-variable inequality + COUNT(DISTINCT)."""
+
+    def test_accounts_receiving_from_multiple_senders(self, spark, graph):
+        """"Which accounts receive transfers from more than one sender?"
+
+        In-edges by target:
+          A2 <- {A1, A5}     two distinct senders
+          A3 <- {A2}
+          A4 <- {A3}
+          A5 <- {A1}
+          A6 <- {A5, A6}     two distinct senders (A6 via its self-loop)
+          A7 <- {A4}
+
+        The ``x.node_id < y.node_id`` guard keeps each unordered sender pair
+        once and excludes ``x = y``.  Pairs that survive:
+          A2: (A1, A5) -> 1 pair
+          A6: (A5, A6) -> 1 pair
+
+        So both A2 and A6 have exactly one qualifying sender pair.  A6
+        qualifies *because* of its self-loop: A6 is a genuine second sender
+        into A6, distinct from A5.
+
+        Expected: [('A2', 1), ('A6', 1)].
+        """
+        query = """
+        MATCH (x:Account)-[:TRANSFER]->(mid:Account)
+        MATCH (y:Account)-[:TRANSFER]->(mid)
+        WHERE x.node_id < y.node_id
+        RETURN mid.node_id AS shared, COUNT(*) AS sender_pairs
+        ORDER BY shared
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["shared"], r["sender_pairs"]) for r in rows]
+        assert results == [("A2", 1), ("A6", 1)], (
+            f"Expected [('A2', 1), ('A6', 1)], got {results}. A2 receives "
+            f"from A1 and A5; A6 receives from A5 and from itself."
+        )
+
+
+class TestUnboundedTraversalReachability:
+    """Unbounded ``*`` on a graph whose diameter is well under the cap."""
+
+    def test_full_reachability_from_a1(self, spark, graph):
+        """Every account reachable from A1, with no explicit depth bound.
+
+        A1 -> {A2, A5} -> {A3, A6} -> {A4} -> {A7}.  A6's self-loop adds
+        nothing new.  A8 and A9 have no edges and are unreachable.
+
+        Expected: {A2, A3, A4, A5, A6, A7}.
+
+        The fixture's longest path from A1 is 4 hops, comfortably below the
+        transpiler's default ceiling of 10 for unbounded VLP -- so this test
+        measures reachability, not the cap.  The cap itself is asserted in
+        ``tests/test_unbounded_vlp_depth_cap.py``.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER*]->(b:Account)
+        WHERE a.node_id = 'A1'
+        RETURN DISTINCT b.node_id AS id
+        ORDER BY id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [r["id"] for r in rows]
+        assert results == ["A2", "A3", "A4", "A5", "A6", "A7"], (
+            f"Expected all six reachable accounts, got {results}"
+        )

--- a/tests/pyspark_tests/test_null_semantics_pyspark.py
+++ b/tests/pyspark_tests/test_null_semantics_pyspark.py
@@ -1,0 +1,240 @@
+"""NULL propagation and deduplication semantics.
+
+Two areas the suite does not cover:
+
+* **Three-valued logic.**  ``NULL`` is neither TRUE nor FALSE, so a row with a
+  NULL property must be excluded by both ``WHERE x > k`` *and*
+  ``WHERE NOT (x > k)``.  The only NULL path currently tested anywhere is
+  ``COALESCE`` inside a VLP node predicate
+  (``test_nodes_path_predicates_pyspark.py``).
+* **Deduplication beyond a single column.**  The catalog counts 373 queries
+  mentioning ``DISTINCT``, but they are overwhelmingly
+  ``RETURN DISTINCT <one column>``.  Multi-column dedup and
+  ``COUNT(DISTINCT)`` over a nullable column are untested.
+
+Fixture B -- ``people``::
+
+    Alice ──KNOWS──► Bob ──KNOWS──► Carol
+    Dave  ──KNOWS──► Dave    (self-loop)
+    Erin                     (isolated)
+
+    id  name   age  salary
+    P1  Alice   30   100.0
+    P2  Bob     40   NULL     <- NULL salary
+    P3  Carol   30   200.0    <- duplicate age with Alice
+    P4  Dave    50   NULL     <- NULL salary, self-loop
+    P5  Erin    25   300.0    <- isolated
+
+Two NULL salaries (Bob, Dave) and a duplicated age (30, shared by Alice and
+Carol) are the load-bearing properties.
+"""
+
+import pytest
+
+from tests.utils.spark_session import new_test_session
+
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Isolated child session. Never call spark.stop() -- see tests/utils."""
+    session = new_test_session()
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW ns_nodes AS
+        SELECT * FROM VALUES
+            ('P1', 'Person', 'Alice', 30, CAST(100.0 AS DOUBLE)),
+            ('P2', 'Person', 'Bob',   40, CAST(NULL  AS DOUBLE)),
+            ('P3', 'Person', 'Carol', 30, CAST(200.0 AS DOUBLE)),
+            ('P4', 'Person', 'Dave',  50, CAST(NULL  AS DOUBLE)),
+            ('P5', 'Person', 'Erin',  25, CAST(300.0 AS DOUBLE))
+        AS t(node_id, node_type, name, age, salary)
+    """)
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW ns_edges AS
+        SELECT * FROM VALUES
+            ('P1', 'P2', 'KNOWS'),
+            ('P2', 'P3', 'KNOWS'),
+            ('P4', 'P4', 'KNOWS')
+        AS t(src, dst, relationship_type)
+    """)
+    return session
+
+
+@pytest.fixture(scope="module")
+def graph(spark):
+    from gsql2rsql import GraphContext
+
+    ctx = GraphContext(
+        spark=spark,
+        nodes_table="ns_nodes",
+        edges_table="ns_edges",
+        node_id_col="node_id",
+        node_type_col="node_type",
+        edge_type_col="relationship_type",
+        edge_src_col="src",
+        edge_dst_col="dst",
+        extra_node_attrs={"name": str, "age": int, "salary": float},
+    )
+    ctx.set_types(node_types=["Person"], edge_types=["KNOWS"])
+    return ctx
+
+
+class TestThreeValuedLogic:
+    """A NULL operand makes a comparison NULL -- neither TRUE nor FALSE."""
+
+    def test_greater_than_excludes_null(self, spark, graph):
+        """``salary > 150``: Carol (200) and Erin (300).
+
+        Bob and Dave have NULL salaries, so the comparison is NULL and the
+        rows are dropped.  Alice (100) fails on value.
+        """
+        query = """
+        MATCH (p:Person) WHERE p.salary > 150
+        RETURN p.name AS name ORDER BY name
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        assert [r["name"] for r in rows] == ["Carol", "Erin"]
+
+    def test_negated_comparison_also_excludes_null(self, spark, graph):
+        """``NOT (salary > 150)``: Alice only.
+
+        The discriminating case.  ``NOT NULL`` is NULL, so Bob and Dave must
+        be excluded here *as well as* from the un-negated test above -- the
+        two results do not partition the five people.  A transpiler that
+        coalesced the inner comparison to FALSE before negating would wrongly
+        return Alice, Bob and Dave.
+        """
+        query = """
+        MATCH (p:Person) WHERE NOT (p.salary > 150)
+        RETURN p.name AS name ORDER BY name
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        names = [r["name"] for r in rows]
+        assert names == ["Alice"], (
+            f"Expected ['Alice'], got {names}. Bob and Dave have NULL "
+            f"salaries: NOT(NULL > 150) is NULL, not TRUE, so they must be "
+            f"excluded from the negated predicate too."
+        )
+
+    def test_is_null_is_the_only_way_to_select_nulls(self, spark, graph):
+        """``IS NULL`` returns exactly the two people the comparisons dropped."""
+        query = """
+        MATCH (p:Person) WHERE p.salary IS NULL
+        RETURN p.name AS name ORDER BY name
+        """
+        sql = graph.transpile(query)
+        rows = spark.sql(sql).collect()
+        assert [r["name"] for r in rows] == ["Bob", "Dave"]
+
+    def test_aggregates_skip_nulls(self, spark, graph):
+        """AVG/SUM/COUNT ignore NULL; COUNT(*) does not.
+
+        Salaries: 100, NULL, 200, NULL, 300.
+        AVG = (100+200+300)/3 = 200.0, SUM = 600.0,
+        COUNT(salary) = 3, COUNT(*) = 5.
+        """
+        query = """
+        MATCH (p:Person)
+        RETURN AVG(p.salary) AS avg_sal, SUM(p.salary) AS sum_sal,
+               COUNT(p.salary) AS n_sal, COUNT(*) AS n_rows
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        assert len(rows) == 1
+        row = rows[0]
+        assert float(row["avg_sal"]) == pytest.approx(200.0, abs=0.01)
+        assert float(row["sum_sal"]) == pytest.approx(600.0, abs=0.01)
+        assert row["n_sal"] == 3, row["n_sal"]
+        assert row["n_rows"] == 5, row["n_rows"]
+
+    def test_avg_over_all_null_group_is_null_not_zero(self, spark, graph):
+        """AVG over a group with no non-NULL values is NULL, not 0.
+
+        Restricting to the NULL-salary people leaves nothing to average.
+        """
+        query = """
+        MATCH (p:Person) WHERE p.salary IS NULL
+        RETURN AVG(p.salary) AS avg_sal, COUNT(*) AS n_rows
+        """
+        sql = graph.transpile(query)
+        rows = spark.sql(sql).collect()
+        assert len(rows) == 1
+        assert rows[0]["avg_sal"] is None, (
+            f"AVG over an all-NULL group must be NULL, got {rows[0]['avg_sal']}"
+        )
+        assert rows[0]["n_rows"] == 2
+
+
+class TestDeduplication:
+    """DISTINCT across several columns, and over nullable input."""
+
+    def test_distinct_multi_column(self, spark, graph):
+        """``DISTINCT a.age, b.age`` over the two KNOWS edges.
+
+        Edges (excluding the Dave self-loop, which pairs 50 with 50):
+          Alice(30) -> Bob(40)    -> (30, 40)
+          Bob(40)   -> Carol(30)  -> (40, 30)
+          Dave(50)  -> Dave(50)   -> (50, 50)
+
+        All three pairs are distinct, so dedup changes nothing here -- the
+        assertion is that the pair *combination* is preserved rather than
+        each column being deduplicated independently (which would give the
+        cross-product of {30,40,50} x {30,40,50}).
+        """
+        query = """
+        MATCH (a:Person)-[:KNOWS]->(b:Person)
+        RETURN DISTINCT a.age AS a_age, b.age AS b_age
+        ORDER BY a_age, b_age
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = [(r["a_age"], r["b_age"]) for r in rows]
+        assert results == [(30, 40), (40, 30), (50, 50)], results
+
+    def test_count_distinct_excludes_null(self, spark, graph):
+        """``COUNT(DISTINCT salary)`` = 3; NULL is not a distinct value.
+
+        Salaries 100, NULL, 200, NULL, 300 -> three distinct non-NULL values.
+        A implementation counting NULL as a value would return 4.
+        """
+        query = """
+        MATCH (p:Person)
+        RETURN COUNT(DISTINCT p.salary) AS n
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        assert rows[0]["n"] == 3, (
+            f"Expected 3 distinct non-NULL salaries, got {rows[0]['n']}"
+        )
+
+    def test_count_distinct_collapses_duplicates(self, spark, graph):
+        """``COUNT(DISTINCT age)`` = 4; Alice and Carol share age 30.
+
+        Ages 30, 40, 30, 50, 25 -> {25, 30, 40, 50} = 4 distinct.
+        """
+        query = "MATCH (p:Person) RETURN COUNT(DISTINCT p.age) AS n"
+        sql = graph.transpile(query)
+        rows = spark.sql(sql).collect()
+        assert rows[0]["n"] == 4, rows[0]["n"]
+
+    def test_distinct_single_column_collapses(self, spark, graph):
+        """Control: single-column DISTINCT over the duplicated age."""
+        query = """
+        MATCH (p:Person) RETURN DISTINCT p.age AS age ORDER BY age
+        """
+        sql = graph.transpile(query)
+        rows = spark.sql(sql).collect()
+        assert [r["age"] for r in rows] == [25, 30, 40, 50]

--- a/tests/pyspark_tests/test_repeated_variable_patterns_pyspark.py
+++ b/tests/pyspark_tests/test_repeated_variable_patterns_pyspark.py
@@ -1,0 +1,228 @@
+"""Execution tests: a repeated variable must constrain both pattern endpoints.
+
+Fixture A -- ``payments``, an account-transfer graph::
+
+                   (frozen)
+    A1 ──────► A2 ──────► A3 ──────► A4
+    ▲ │          ▲         │          │
+    │ │          │         │          ▼
+    │ └────────► A5 ──────► A6       A7  (leaf, no outgoing edges)
+    │                       │
+    └───────── A3           └──► A6   (SELF-LOOP)
+      (A3 -> A1 closes the A1->A2->A3->A1 triangle)
+
+    A8  (isolated -- no edges at all)
+    A9  (NULL risk_score, no edges)
+
+The self-loop ``A6 -> A6`` and the single genuine 3-cycle
+``A1 -> A2 -> A3 -> A1`` are the two load-bearing properties for this
+module.
+
+Structural counterpart: ``tests/test_repeated_variable_join.py`` (runs in CI;
+the PySpark suites do not).
+"""
+
+import pytest
+
+from tests.utils.spark_session import new_test_session
+
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Isolated child session. Never call spark.stop() -- see tests/utils."""
+    session = new_test_session()
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW rv_nodes AS
+        SELECT * FROM VALUES
+            ('A1', 'Account', 90,   'active', 'Lisboa'),
+            ('A2', 'Account', 20,   'frozen', 'Lisboa'),
+            ('A3', 'Account', 55,   'active', 'Porto'),
+            ('A4', 'Account', 70,   'active', 'Porto'),
+            ('A5', 'Account', 40,   'active', 'Lisboa'),
+            ('A6', 'Account', 85,   'active', 'Porto'),
+            ('A7', 'Account', 30,   'active', 'Braga'),
+            ('A8', 'Account', 10,   'active', 'Braga'),
+            ('A9', 'Account', CAST(NULL AS INT), 'active', 'Lisboa')
+        AS t(node_id, node_type, risk_score, status, city)
+    """)
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW rv_edges AS
+        SELECT * FROM VALUES
+            ('A1', 'A2', 'TRANSFER', 1000),
+            ('A1', 'A5', 'TRANSFER',  500),
+            ('A2', 'A3', 'TRANSFER', 2000),
+            ('A3', 'A1', 'TRANSFER',  400),
+            ('A3', 'A4', 'TRANSFER',  300),
+            ('A4', 'A7', 'TRANSFER',  750),
+            ('A5', 'A2', 'TRANSFER',  600),
+            ('A5', 'A6', 'TRANSFER',  900),
+            ('A6', 'A6', 'TRANSFER',  250)
+        AS t(src, dst, relationship_type, amount)
+    """)
+    return session
+
+
+@pytest.fixture(scope="module")
+def graph(spark):
+    from gsql2rsql import GraphContext
+
+    ctx = GraphContext(
+        spark=spark,
+        nodes_table="rv_nodes",
+        edges_table="rv_edges",
+        node_id_col="node_id",
+        node_type_col="node_type",
+        edge_type_col="relationship_type",
+        edge_src_col="src",
+        edge_dst_col="dst",
+        extra_node_attrs={"risk_score": int, "status": str, "city": str},
+        extra_edge_attrs={"amount": int},
+    )
+    ctx.set_types(node_types=["Account"], edge_types=["TRANSFER"])
+    return ctx
+
+
+class TestSelfLoopRepeatedVariable:
+    """``(a)-[:TRANSFER]->(a)`` returns only accounts that transfer to self."""
+
+    def test_self_loop_only(self, spark, graph):
+        """Expected: {A6}.
+
+        A6 -> A6 is the only edge whose src equals its dst.  A1, A2, A3, A4
+        and A5 all have outgoing transfers but none to themselves, so a
+        transpiler that constrains only ``a.node_id = edge.src`` returns all
+        six -- the silent wrong answer this test exists to catch.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(a)
+        RETURN a.node_id AS id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = {row["id"] for row in rows}
+        assert results == {"A6"}, (
+            f"Expected only the self-loop account A6, got {sorted(results)}. "
+            f"Accounts with any outgoing transfer are A1-A6; if all of them "
+            f"appear, the edge's sink was never bound back to 'a'."
+        )
+
+    def test_self_loop_with_property_filter(self, spark, graph):
+        """Same pattern plus a filter -- must still be self-loops only.
+
+        A6 has risk_score 85 > 50, so the expected set is unchanged.  A
+        transpiler returning all senders would also return A1 (90) and A4
+        (70), which pass the filter too.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(a)
+        WHERE a.risk_score > 50
+        RETURN a.node_id AS id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = {row["id"] for row in rows}
+        assert results == {"A6"}, f"Expected {{A6}}, got {sorted(results)}"
+
+    def test_control_distinct_variables_returns_all_edges(self, spark, graph):
+        """Control: with two distinct variables, all 8 edges must come back.
+
+        Guards the two tests above -- proves the fixture and the join work in
+        general, so a failure there is specific to the repeated variable.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(b:Account)
+        RETURN a.node_id AS src, b.node_id AS dst
+        """
+        sql = graph.transpile(query)
+        rows = spark.sql(sql).collect()
+        results = {(r["src"], r["dst"]) for r in rows}
+        expected = {
+            ("A1", "A2"), ("A1", "A5"), ("A2", "A3"), ("A3", "A1"),
+            ("A3", "A4"), ("A4", "A7"), ("A5", "A2"), ("A5", "A6"),
+            ("A6", "A6"),
+        }
+        assert results == expected, f"Expected {expected}, got {results}"
+
+
+class TestClosedTriangle:
+    """A 3-cycle pattern must close back onto the first variable."""
+
+    TRIANGLE_QUERY = """
+    MATCH (a:Account)-[:TRANSFER]->(b:Account)-[:TRANSFER]->(c:Account)
+          -[:TRANSFER]->(a)
+    RETURN DISTINCT a.node_id AS id
+    """
+
+    def test_triangle_cycle_closes(self, spark, graph):
+        """The genuine triangle is found; non-cycling 3-paths are excluded.
+
+        Genuine 3-cycle: A1->A2->A3->A1, matched from each rotation, so
+        a in {A1, A2, A3}.  A6 also appears because the transpiler reuses
+        the single self-loop edge A6->A6 for all three hops -- openCypher's
+        relationship uniqueness forbids that, but the transpiler does not
+        enforce it (documented limitation; strict test below is xfail).
+
+        The load-bearing assertion is the *absence* of A4, A5, A7-A9:
+        plenty of non-cycling 3-hop paths start there (A5->A2->A3->A4,
+        A2->A3->A4->A7, ...), so before the closing-join fix this returned
+        them all.
+        """
+        sql = graph.transpile(self.TRIANGLE_QUERY)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = {row["id"] for row in rows}
+        assert results == {"A1", "A2", "A3", "A6"}, (
+            f"Expected the A1->A2->A3->A1 triangle members plus the "
+            f"self-loop reuse artefact A6, got {sorted(results)}. Any of "
+            f"A4/A5/A7 present means the final hop was not joined back "
+            f"to 'a'."
+        )
+
+    @pytest.mark.xfail(
+        reason="Relationship uniqueness (edge isomorphism) is not enforced: "
+        "the single self-loop edge A6->A6 is reused for all three pattern "
+        "relationships, which openCypher forbids. Documented in "
+        "docs_help_dev/limitations.md.",
+        strict=True,
+    )
+    def test_triangle_strict_relationship_uniqueness(self, spark, graph):
+        """Strict openCypher: each pattern relationship binds a distinct edge.
+
+        Under edge isomorphism only the genuine triangle qualifies, so the
+        expected set is exactly {A1, A2, A3} -- no A6.
+        """
+        sql = graph.transpile(self.TRIANGLE_QUERY)
+        rows = spark.sql(sql).collect()
+        results = {row["id"] for row in rows}
+        assert results == {"A1", "A2", "A3"}, sorted(results)
+
+    def test_two_hop_return_to_origin(self, spark, graph):
+        """``(a)->(b)->(a)`` -- a 2-cycle. Expected today: {A6}.
+
+        No genuine 2-cycle exists (no pair of accounts transfers in both
+        directions).  A6 matches only by reusing the self-loop edge for
+        both hops -- the same relationship-uniqueness gap as above; strict
+        openCypher would return {}.  Locked in as current behaviour so the
+        closing join itself stays covered: before the fix this returned
+        every 2-path origin {A1, A2, A3, A5, A6}.
+        """
+        query = """
+        MATCH (a:Account)-[:TRANSFER]->(b:Account)-[:TRANSFER]->(a)
+        RETURN DISTINCT a.node_id AS id
+        """
+        sql = graph.transpile(query)
+        print(f"\n=== SQL ===\n{sql}")
+
+        rows = spark.sql(sql).collect()
+        results = {row["id"] for row in rows}
+        assert results == {"A6"}, (
+            f"Expected {{A6}} (self-loop edge reused for both hops; no "
+            f"genuine 2-cycle exists), got {sorted(results)}"
+        )

--- a/tests/pyspark_tests/test_scalar_function_values_pyspark.py
+++ b/tests/pyspark_tests/test_scalar_function_values_pyspark.py
@@ -1,0 +1,196 @@
+"""Scalar functions asserted by *value*, not by template substring.
+
+``test_function_registry.py`` validates the registry data and
+``test_30_math_functions.py`` asserts template substrings.  Neither proves the
+mapping is *semantically* right -- and two of them are not:
+
+* ``size(<string>)`` renders to Spark's ``SIZE()``, which accepts array/map
+  only.  In Cypher ``size()`` on a string is its character count.
+* ``list + list`` renders to SQL ``+``, which Spark has no array overload for.
+  ``pyspark_tests/test_string_concat_pyspark.py`` already proves ``+`` is
+  special-cased for *strings*; the array case is the missing sibling.
+
+Fixture B -- ``people`` (with a ``tags`` array column added)::
+
+    id  name     age  tags
+    P1  Alice     30  ['vip', 'eu']
+    P2  Bob       40  ['eu']
+    P3  Carol     30  []
+"""
+
+import pytest
+
+from tests.utils.spark_session import new_test_session
+
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Isolated child session. Never call spark.stop() -- see tests/utils."""
+    session = new_test_session()
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW sf_nodes AS
+        SELECT * FROM VALUES
+            ('P1', 'Person', 'Alice', 30, ARRAY('vip', 'eu')),
+            ('P2', 'Person', 'Bob',   40, ARRAY('eu')),
+            ('P3', 'Person', 'Carol', 30, ARRAY())
+        AS t(node_id, node_type, name, age, tags)
+    """)
+    session.sql("""
+        CREATE OR REPLACE TEMPORARY VIEW sf_edges AS
+        SELECT * FROM VALUES ('P1', 'P2', 'KNOWS')
+        AS t(src, dst, relationship_type)
+    """)
+    return session
+
+
+@pytest.fixture(scope="module")
+def graph(spark):
+    from gsql2rsql import GraphContext
+
+    ctx = GraphContext(
+        spark=spark,
+        nodes_table="sf_nodes",
+        edges_table="sf_edges",
+        node_id_col="node_id",
+        node_type_col="node_type",
+        edge_type_col="relationship_type",
+        edge_src_col="src",
+        edge_dst_col="dst",
+        extra_node_attrs={"name": str, "age": int, "tags": list},
+    )
+    ctx.set_types(node_types=["Person"], edge_types=["KNOWS"])
+    return ctx
+
+
+def _one(spark, graph, cypher: str):
+    sql = graph.transpile(cypher)
+    print(f"\n=== SQL ===\n{sql}")
+    return spark.sql(sql).collect()
+
+
+class TestStringFunctionValues:
+    """String functions must return the values Cypher specifies."""
+
+    @pytest.mark.parametrize(
+        "expr,expected",
+        [
+            ("toUpper(p.name)", "ALICE"),
+            ("toLower(p.name)", "alice"),
+            ("trim(p.name)", "Alice"),
+            ("toString(p.age)", "30"),
+            ("left(p.name, 3)", "Ali"),
+            ("right(p.name, 3)", "ice"),
+        ],
+    )
+    def test_string_function_value(
+        self, spark, graph, expr: str, expected: str
+    ) -> None:
+        rows = _one(
+            spark,
+            graph,
+            f"MATCH (p:Person) WHERE p.name = 'Alice' RETURN {expr} AS v",
+        )
+        assert len(rows) == 1
+        assert rows[0]["v"] == expected, f"{expr} -> {rows[0]['v']}"
+
+    @pytest.mark.parametrize(
+        "expr,expected",
+        [
+            ("toInteger(p.age)", 30),
+            ("toFloat(p.age)", 30.0),
+        ],
+    )
+    def test_cast_function_value(
+        self, spark, graph, expr: str, expected: object
+    ) -> None:
+        rows = _one(
+            spark,
+            graph,
+            f"MATCH (p:Person) WHERE p.name = 'Alice' RETURN {expr} AS v",
+        )
+        assert len(rows) == 1
+        assert rows[0]["v"] == expected, f"{expr} -> {rows[0]['v']}"
+
+    def test_size_of_string_is_character_count(self, spark, graph) -> None:
+        """``size('Alice')`` is 5 in Cypher.
+
+        EXPECTED TO FAIL -- the renderer emits Spark's ``SIZE()``, which
+        accepts array/map only, so this raises a type error at execution
+        rather than returning 5.  The authoritative type system already knows
+        the operand is a string, so ``LENGTH()`` is selectable.
+        """
+        rows = _one(
+            spark,
+            graph,
+            "MATCH (p:Person) WHERE p.name = 'Alice' "
+            "RETURN size(p.name) AS v",
+        )
+        assert rows[0]["v"] == 5, (
+            f"size('Alice') must be 5, got {rows[0]['v']}"
+        )
+
+
+class TestListFunctionValues:
+    """List operations must produce arrays, not arithmetic."""
+
+    def test_size_of_list(self, spark, graph) -> None:
+        """Control: ``size()`` over an array is already correct."""
+        rows = _one(
+            spark,
+            graph,
+            "MATCH (p:Person) WHERE p.name = 'Alice' "
+            "RETURN size(p.tags) AS v",
+        )
+        assert rows[0]["v"] == 2, rows[0]["v"]
+
+    def test_list_concatenation(self, spark, graph) -> None:
+        """``['vip','eu'] + ['extra']`` is ``['vip','eu','extra']``.
+
+        EXPECTED TO FAIL -- renders as SQL ``(tags) + (('extra'))``.  Spark
+        has no ``+`` operator for arrays, so this is a type error at
+        execution.  ``CONCAT()`` is the correct Databricks form.
+        """
+        rows = _one(
+            spark,
+            graph,
+            "MATCH (p:Person) WHERE p.name = 'Alice' "
+            "RETURN p.tags + ['extra'] AS v",
+        )
+        assert list(rows[0]["v"]) == ["vip", "eu", "extra"], rows[0]["v"]
+
+    def test_list_plus_list_property(self, spark, graph) -> None:
+        """Concatenating two array-typed properties.
+
+        EXPECTED TO FAIL for the same reason as above.
+        """
+        rows = _one(
+            spark,
+            graph,
+            "MATCH (p:Person) WHERE p.name = 'Alice' "
+            "RETURN p.tags + p.tags AS v",
+        )
+        assert list(rows[0]["v"]) == ["vip", "eu", "vip", "eu"], rows[0]["v"]
+
+
+class TestStringConcatControl:
+    """Control: string ``+`` is special-cased correctly and must stay so."""
+
+    def test_string_plus_string(self, spark, graph) -> None:
+        rows = _one(
+            spark,
+            graph,
+            "MATCH (p:Person) WHERE p.name = 'Alice' "
+            "RETURN 'Hi ' + p.name AS v",
+        )
+        assert rows[0]["v"] == "Hi Alice", rows[0]["v"]
+
+    def test_numeric_plus_numeric(self, spark, graph) -> None:
+        rows = _one(
+            spark,
+            graph,
+            "MATCH (p:Person) WHERE p.name = 'Alice' "
+            "RETURN p.age + 5 AS v",
+        )
+        assert rows[0]["v"] == 35, rows[0]["v"]

--- a/tests/test_no_label_solution.py
+++ b/tests/test_no_label_solution.py
@@ -6,6 +6,7 @@ TDD - Estes testes devem FALHAR antes da implementação.
 import pytest
 
 from gsql2rsql import GraphContext
+from gsql2rsql.common.exceptions import TranspilerNotSupportedException
 
 
 def test_match_without_label_should_work():
@@ -189,47 +190,42 @@ def test_inline_label_still_works():
     print("✅ Backward compatibility mantido!")
 
 
-def test_where_overrides_inline():
-    """WHERE a:Company deve sobrescrever (a:Person) inline."""
+def test_where_label_predicate_is_rejected_loudly():
+    """``WHERE a:Company`` raises until label predicates are implemented.
+
+    The previous version of this test asserted that both `'Person'` and
+    `'Company'` appeared in the SQL — but the `'Company'` match was
+    satisfied by the pattern's own ``(c:Company)`` label, not by the WHERE
+    clause. The label predicate itself was silently dropped (the WHERE
+    rendered as a bare, non-boolean ``_gsql2rsql_a_id`` column), so the
+    assertion was vacuously green over a silent wrong answer.
+
+    The transpiler now rejects the construct with an actionable error;
+    this test locks that contract in until the feature lands (see the
+    5 skip-marked tests in test_where_label_predicates.py).
+    """
     graph = GraphContext(
         nodes_table="catalog.schema.nodes",
         edges_table="catalog.schema.edges",
         extra_node_attrs={"name": str},
-        
     )
     graph.set_types(
         node_types=["Person", "Company"],
         edge_types=["WORKS_AT"]
     )
 
-    print("\n" + "=" * 80)
-    print("TESTE 5: WHERE sobrescreve label inline")
-    print("=" * 80)
-
-    # Caso edge: label inline diferente do WHERE
-    # OpenCypher: WHERE a:Company sobrescreve (a:Person)
-    # Resultado: retorna vazio (impossível ser Person E Company)
     query = """
     MATCH (a:Person)-[:WORKS_AT]->(c:Company)
     WHERE a:Company
     RETURN a.name
     """
 
-    print("Query:")
-    print(query)
+    with pytest.raises(TranspilerNotSupportedException) as exc_info:
+        graph.transpile(query)
 
-    sql = graph.transpile(query)
-
-    print("\n✅ SUCESSO! SQL gerado:")
-    print(sql)
-
-    # SQL deve ter ambos os filtros (Person do inline, Company do WHERE)
-    # Isso resulta em query vazia (AND impossível), mas é semanticamente
-    # correto
-    assert "'Person'" in sql or "node_type = 'Person'" in sql
-    assert "'Company'" in sql or "node_type = 'Company'" in sql
-
-    print("✅ Ambos os filtros presentes (query vazia esperada)!")
+    message = str(exc_info.value)
+    assert "Label predicate" in message or "label predicate" in message
+    assert "Company" in message
 
 
 def test_variable_path_without_labels():

--- a/tests/test_parameterized_pagination.py
+++ b/tests/test_parameterized_pagination.py
@@ -1,0 +1,129 @@
+"""Parameters in ``SKIP`` / ``LIMIT`` must not be silently discarded.
+
+``test_22_parameterized_in.py`` covers ``$param`` inside ``WHERE ... IN``.
+Nothing covers it in a pagination clause, and there the parameter is dropped:
+``RETURN p.name LIMIT $n`` produces SQL with **no ``LIMIT`` at all**, so the
+query returns the entire result set.
+
+A literal ``LIMIT 10`` works, which is what makes this dangerous -- pagination
+appears to work until someone parameterises it.
+
+Either outcome is acceptable:
+
+* emit a parameter marker (``LIMIT :n``), or
+* reject the query with a transpiler error.
+
+Silently returning every row is not.
+"""
+
+import re
+
+import pytest
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.exceptions import TranspilerException
+from gsql2rsql.common.schema import NodeSchema, EntityProperty
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+
+def _schema() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[
+                EntityProperty("id", int),
+                EntityProperty("name", str),
+                EntityProperty("age", int),
+            ],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="g.Person", node_id_columns=["id"]),
+    )
+    return schema
+
+
+def _render(cypher: str) -> str:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+class TestLiteralPaginationControl:
+    """Control group: literal SKIP/LIMIT work and must keep working."""
+
+    def test_literal_limit_renders(self) -> None:
+        sql = _render("MATCH (p:Person) RETURN p.name AS name LIMIT 10")
+        assert re.search(r"\bLIMIT\b", sql, re.IGNORECASE), sql
+
+    def test_literal_skip_and_limit_render(self) -> None:
+        sql = _render(
+            "MATCH (p:Person) RETURN p.name AS name SKIP 5 LIMIT 10"
+        )
+        assert re.search(r"\bLIMIT\b", sql, re.IGNORECASE), sql
+        assert re.search(r"\bOFFSET\b|\bSKIP\b", sql, re.IGNORECASE), sql
+
+
+class TestParameterizedPagination:
+    """``LIMIT $n`` / ``SKIP $s`` must bind or be rejected -- never dropped."""
+
+    def test_parameterized_limit_is_not_dropped(self) -> None:
+        """``LIMIT $n`` must not vanish from the generated SQL.
+
+        Without it the query returns every row, which for a pagination query
+        against a large table is both a wrong answer and a performance
+        incident.
+        """
+        cypher = "MATCH (p:Person) RETURN p.name AS name LIMIT $n"
+        try:
+            sql = _render(cypher)
+        except TranspilerException:
+            return  # Acceptable: rejected clearly.
+
+        print(f"\n=== SQL ===\n{sql}")
+        assert re.search(r"\bLIMIT\b", sql, re.IGNORECASE), (
+            f"LIMIT $n was silently discarded -- the generated SQL has no "
+            f"LIMIT clause and returns every row:\n{sql}"
+        )
+
+    def test_parameterized_skip_and_limit_are_not_dropped(self) -> None:
+        """Both pagination parameters must survive."""
+        cypher = "MATCH (p:Person) RETURN p.name AS name SKIP $s LIMIT $n"
+        try:
+            sql = _render(cypher)
+        except TranspilerException:
+            return
+
+        print(f"\n=== SQL ===\n{sql}")
+        assert re.search(r"\bLIMIT\b", sql, re.IGNORECASE), (
+            f"LIMIT $n was silently discarded:\n{sql}"
+        )
+        assert re.search(r"\bOFFSET\b|\bSKIP\b", sql, re.IGNORECASE), (
+            f"SKIP $s was silently discarded:\n{sql}"
+        )
+
+    def test_parameterized_limit_with_order_by(self) -> None:
+        """The top-N idiom: ``ORDER BY ... LIMIT $n``.
+
+        Dropping the LIMIT here turns a top-N query into a full sort of the
+        entire table.
+        """
+        cypher = (
+            "MATCH (p:Person) RETURN p.name AS name "
+            "ORDER BY p.age DESC LIMIT $n"
+        )
+        try:
+            sql = _render(cypher)
+        except TranspilerException:
+            return
+
+        print(f"\n=== SQL ===\n{sql}")
+        assert re.search(r"\bORDER BY\b", sql, re.IGNORECASE), sql
+        assert re.search(r"\bLIMIT\b", sql, re.IGNORECASE), (
+            f"ORDER BY survived but LIMIT $n was dropped:\n{sql}"
+        )

--- a/tests/test_projection_naming.py
+++ b/tests/test_projection_naming.py
@@ -1,0 +1,186 @@
+"""Output column names are a user-facing contract.
+
+Two defects covered here:
+
+* ``RETURN a.name, b.name`` emits two columns both named ``name``.  In Cypher
+  they are ``a.name`` and ``b.name``.  Anything selecting by name downstream
+  (a ``WITH``, ``df.select("name")``, a BI tool) gets the wrong column or an
+  ambiguity error.
+* ``RETURN *`` exposes the transpiler's internal ``_gsql2rsql_*`` names.
+
+Both are asserted on the *set of output column names*, never on the specific
+naming scheme, so a legitimate rename of the internal prefix does not break
+these tests -- only losing the contract does.
+
+``test_unaliased_projection_alias.py`` covers unaliased *aggregations* getting
+a name at all; it does not cover collisions between two variables' same-named
+properties, nor ``RETURN *``.
+"""
+
+import re
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.schema import (
+    NodeSchema,
+    EdgeSchema,
+    EntityProperty,
+)
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+INTERNAL_PREFIX = "_gsql2rsql_"
+
+
+def _schema() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[
+                EntityProperty("id", int),
+                EntityProperty("name", str),
+                EntityProperty("age", int),
+            ],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="g.Person", node_id_columns=["id"]),
+    )
+    schema.add_edge(
+        EdgeSchema(
+            name="KNOWS",
+            source_node_id="Person",
+            sink_node_id="Person",
+            source_id_property=EntityProperty("src", int),
+            sink_id_property=EntityProperty("dst", int),
+        ),
+        SQLTableDescriptor(
+            entity_id="Person@KNOWS@Person",
+            table_name="g.Knows",
+            node_id_columns=["src", "dst"],
+        ),
+    )
+    return schema
+
+
+def _render(cypher: str) -> str:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+def _outermost_select_aliases(sql: str) -> list[str]:
+    """Extract the ``AS <name>`` aliases of the outermost SELECT list.
+
+    The outermost SELECT is everything before the first top-level ``FROM``
+    (nesting depth 0).  Only the alias names are returned, so the expressions
+    feeding them may change freely.
+    """
+    depth = 0
+    end = len(sql)
+    for i, ch in enumerate(sql):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and sql[i : i + 4].upper() == "FROM":
+            # Guard against matching "FROM" inside an identifier.
+            before = sql[i - 1] if i else " "
+            if not before.isalnum() and before != "_":
+                end = i
+                break
+    head = sql[:end]
+    return re.findall(r"\bAS\s+([A-Za-z_`][\w`.]*)", head)
+
+
+class TestAliasCollisions:
+    """Two variables' same-named properties must not collide."""
+
+    def test_two_variables_same_property_get_distinct_names(self) -> None:
+        """``RETURN a.name, b.name`` must produce two distinguishable columns.
+
+        openCypher names them ``a.name`` and ``b.name``.  Any scheme that keeps
+        them distinct (``a_name``/``b_name``) is acceptable; two columns both
+        called ``name`` is not.
+        """
+        cypher = "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name"
+        sql = _render(cypher)
+        print(f"\n=== SQL ===\n{sql}")
+
+        aliases = _outermost_select_aliases(sql)
+        assert len(aliases) == 2, f"Expected 2 output columns, got {aliases}"
+        assert len(set(aliases)) == 2, (
+            f"Both output columns are named the same thing: {aliases}. "
+            f"In Cypher these are 'a.name' and 'b.name'; anything selecting "
+            f"by name downstream cannot tell them apart.\n{sql}"
+        )
+
+    def test_three_way_collision(self) -> None:
+        """Three variables projecting ``age`` must yield three distinct names."""
+        cypher = (
+            "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) "
+            "RETURN a.age, b.age, c.age"
+        )
+        sql = _render(cypher)
+        print(f"\n=== SQL ===\n{sql}")
+
+        aliases = _outermost_select_aliases(sql)
+        assert len(set(aliases)) == 3, (
+            f"Expected 3 distinct output names, got {aliases}\n{sql}"
+        )
+
+    def test_explicit_aliases_are_respected(self) -> None:
+        """Control: explicit ``AS`` must survive untouched.
+
+        Guards the two tests above -- if this one broke too, the problem would
+        be alias handling in general rather than collision resolution.
+        """
+        cypher = (
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) "
+            "RETURN a.name AS a_name, b.name AS b_name"
+        )
+        sql = _render(cypher)
+        aliases = _outermost_select_aliases(sql)
+        assert set(aliases) == {"a_name", "b_name"}, aliases
+
+
+class TestReturnStarNaming:
+    """``RETURN *`` must not leak internal column names."""
+
+    def test_return_star_does_not_leak_internal_prefix(self) -> None:
+        """The user asked for ``*``; they must not get ``_gsql2rsql_p_name``."""
+        cypher = "MATCH (p:Person) RETURN *"
+        sql = _render(cypher)
+        print(f"\n=== SQL ===\n{sql}")
+
+        aliases = _outermost_select_aliases(sql)
+        leaked = [a for a in aliases if a.startswith(INTERNAL_PREFIX)]
+        assert not leaked, (
+            f"RETURN * exposes internal column names to the user: {leaked}. "
+            f"Expected user-facing names (e.g. 'id', 'name', 'age' or "
+            f"'p.id', 'p.name', 'p.age').\n{sql}"
+        )
+
+    def test_return_star_after_join_does_not_leak(self) -> None:
+        """Same contract once a join has introduced a second variable."""
+        cypher = "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN *"
+        sql = _render(cypher)
+        print(f"\n=== SQL ===\n{sql}")
+
+        aliases = _outermost_select_aliases(sql)
+        leaked = [a for a in aliases if a.startswith(INTERNAL_PREFIX)]
+        assert not leaked, (
+            f"RETURN * after a join exposes internal names: {leaked}\n{sql}"
+        )
+
+    def test_with_star_then_return_does_not_leak(self) -> None:
+        """``WITH *`` passthrough must not change the final naming contract."""
+        cypher = "MATCH (p:Person) WITH * RETURN p.name AS name"
+        sql = _render(cypher)
+        print(f"\n=== SQL ===\n{sql}")
+
+        aliases = _outermost_select_aliases(sql)
+        assert aliases == ["name"], aliases

--- a/tests/test_repeated_variable_join.py
+++ b/tests/test_repeated_variable_join.py
@@ -1,0 +1,167 @@
+"""Repeated pattern variables must constrain BOTH join keys.
+
+When a variable appears at both endpoints of a pattern, openCypher requires
+the edge's source *and* sink to bind to the same node::
+
+    MATCH (a:Person)-[:KNOWS]->(a)     -- self-loops only
+    MATCH (a)-[:KNOWS]->(b)-[:KNOWS]->(c)-[:KNOWS]->(a)  -- closed triangle
+
+Structural counterpart to
+``tests/pyspark_tests/test_repeated_variable_patterns_pyspark.py``, which
+asserts the resulting rows.  These tests inspect the *logical plan*, so they
+localise the defect to a phase without needing a SparkSession -- and they run
+in CI, which the PySpark suites do not.
+
+The existing self-loop suites
+(``pyspark_tests/test_self_loop_dedup_pyspark.py``,
+``test_undirected_optimization.py::test_self_loops_deduplicated``) all use two
+*distinct* variables ``(a)-[:KNOWS]-(b)``.  The repeated-variable form below is
+a different pattern and is not covered by them.
+"""
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.schema import (
+    NodeSchema,
+    EdgeSchema,
+    EntityProperty,
+)
+from gsql2rsql.planner.operators import JoinOperator, LogicalOperator
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+
+def _schema() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[
+                EntityProperty("id", int),
+                EntityProperty("name", str),
+            ],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="g.Person", node_id_columns=["id"]),
+    )
+    schema.add_edge(
+        EdgeSchema(
+            name="KNOWS",
+            source_node_id="Person",
+            sink_node_id="Person",
+            source_id_property=EntityProperty("src", int),
+            sink_id_property=EntityProperty("dst", int),
+        ),
+        SQLTableDescriptor(
+            entity_id="Person@KNOWS@Person",
+            table_name="g.Knows",
+            node_id_columns=["src", "dst"],
+        ),
+    )
+    return schema
+
+
+def _plan(cypher: str) -> LogicalPlan:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return plan
+
+
+def _render(cypher: str) -> str:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+def _join_pairs_for(plan: LogicalPlan, variable: str) -> list[str]:
+    """Collect the join-pair *types* that bind ``variable`` to an edge."""
+    types: list[str] = []
+    seen: set[int] = set()
+    for start_op in plan.starting_operators:
+        for op in start_op.get_all_downstream_operators(LogicalOperator):
+            # A join is reachable from both of its inputs; count it once.
+            if not isinstance(op, JoinOperator) or id(op) in seen:
+                continue
+            seen.add(id(op))
+            for pair in op.join_pairs:
+                if pair.node_alias == variable:
+                    types.append(pair.pair_type.name)
+    return types
+
+
+class TestSelfLoopRepeatedVariable:
+    """``(a)-[:KNOWS]->(a)`` must pin both edge endpoints to ``a``."""
+
+    CYPHER = "MATCH (a:Person)-[:KNOWS]->(a) RETURN a.name AS name"
+
+    def test_parser_keeps_both_endpoints(self) -> None:
+        """The AST must carry both endpoints -- proves this is not a parser bug."""
+        ast = OpenCypherParser().parse(self.CYPHER)
+        rendered = str(ast)
+        # Both the source and the sink node reference the same variable "a".
+        assert rendered.count("a") >= 2, rendered
+
+    def test_plan_binds_variable_as_both_source_and_sink(self) -> None:
+        """The join must carry a SOURCE *and* a SINK pair for ``a``.
+
+        With only the SOURCE pair the SQL constrains ``a.id = edge.src`` and
+        leaves ``edge.dst`` free, so every node with any outgoing edge matches
+        -- not just the self-loops openCypher asks for.
+        """
+        plan = _plan(self.CYPHER)
+        pair_types = _join_pairs_for(plan, "a")
+
+        assert len(pair_types) == 2, (
+            f"Expected 'a' to be joined to the edge twice (as SOURCE and as "
+            f"SINK); got {len(pair_types)} pair(s): {pair_types}. "
+            f"A single pair leaves the other edge endpoint unconstrained.\n"
+            f"Plan:\n{plan.dump_graph()}"
+        )
+        assert any("SOURCE" in t for t in pair_types), pair_types
+        assert any("SINK" in t for t in pair_types), pair_types
+
+    def test_sql_constrains_both_edge_columns(self) -> None:
+        """Both ``src`` and ``dst`` of the edge must appear in a join condition."""
+        sql = _render(self.CYPHER)
+        print(f"\n=== SQL ===\n{sql}")
+
+        # The projected id column for `a` must be equated against BOTH edge
+        # endpoint columns somewhere in the query.
+        assert "_anon1_src" in sql, sql
+        assert "_anon1_dst" in sql, (
+            "The edge's sink column never appears in the SQL, so the "
+            f"self-loop condition cannot be expressed.\n{sql}"
+        )
+
+
+class TestClosedTriangleRepeatedVariable:
+    """``(a)->(b)->(c)->(a)`` must close the cycle back onto ``a``."""
+
+    CYPHER = (
+        "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)"
+        "-[:KNOWS]->(a) RETURN a.name AS name"
+    )
+
+    def test_final_hop_binds_back_to_first_variable(self) -> None:
+        """The third edge's sink must be joined to ``a``.
+
+        Without it the query returns every 3-hop path rather than every
+        triangle -- a silent wrong answer, since 3-paths vastly outnumber
+        triangles in any real graph.
+        """
+        plan = _plan(self.CYPHER)
+        pair_types = _join_pairs_for(plan, "a")
+
+        assert len(pair_types) == 2, (
+            f"Expected 'a' to be bound twice (SOURCE of the first edge, SINK "
+            f"of the third); got {len(pair_types)}: {pair_types}. The cycle "
+            f"never closes.\nPlan:\n{plan.dump_graph()}"
+        )
+        assert any("SINK" in t for t in pair_types), (
+            f"'a' is never bound as the SINK of the closing edge: {pair_types}"
+        )

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,190 @@
+"""Under-specified edge schemas should be rejected at construction time.
+
+An ``EdgeSchema`` with no ``source_id_property`` / ``sink_id_property`` is
+silently accepted.  The renderer then prunes the (non-existent) join-key
+columns out of the edge subquery while still naming them in the ``ON``
+clause, producing SQL that references a column that was never selected::
+
+    INNER JOIN (
+      SELECT 1 AS _dummy FROM Knows        -- join keys pruned away
+    ) AS _right_1 ON
+      _left_1._gsql2rsql_p_id = _right_1._gsql2rsql__anon1_source_id
+
+No user of the public API can reach this state -- ``GraphContext`` always
+populates both properties.  It is reachable only by hand-building an
+``EdgeSchema``, which several ``transpile_tests`` fixtures do.
+
+.. note::
+   ``tests/transpile_tests/test_06_single_hop_relationship.py`` builds exactly
+   this shape and passes because it asserts only ``"JOIN" in sql``.  This
+   module does not modify that test; the conflict is reported in
+   ``test-failures-report.md``.
+"""
+
+import pytest
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.schema import (
+    NodeSchema,
+    EdgeSchema,
+    EntityProperty,
+)
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+CYPHER = "MATCH (p:Person)-[:KNOWS]->(f:Person) RETURN p.name, f.name"
+
+
+def _provider_with_person() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[EntityProperty("id", int), EntityProperty("name", str)],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="dbo.Person", node_id_columns=["id"]),
+    )
+    return schema
+
+
+def _add_knows(
+    schema: SimpleSQLSchemaProvider, *, with_id_properties: bool
+) -> None:
+    kwargs = {}
+    if with_id_properties:
+        kwargs = {
+            "source_id_property": EntityProperty("person1_id", int),
+            "sink_id_property": EntityProperty("person2_id", int),
+        }
+    schema.add_edge(
+        EdgeSchema(
+            name="KNOWS",
+            source_node_id="Person",
+            sink_node_id="Person",
+            **kwargs,
+        ),
+        SQLTableDescriptor(
+            entity_id="Person@KNOWS@Person",
+            table_name="dbo.Knows",
+            node_id_columns=["person1_id", "person2_id"],
+        ),
+    )
+
+
+def _render(schema: SimpleSQLSchemaProvider) -> str:
+    ast = OpenCypherParser().parse(CYPHER)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=CYPHER)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+class TestEdgeSchemaIdPropertyValidation:
+    """Omitting the id properties must not produce un-runnable SQL.
+
+    ``add_edge`` repairs the omission when it can: the descriptor's
+    ``node_id_columns`` are ``[source, sink]`` by convention, so the missing
+    id properties are derived from them. When even that is impossible
+    (fewer than two columns), it rejects at construction time -- with the
+    schema author present -- instead of failing at query time with an
+    ``UNRESOLVED_COLUMN`` error from Databricks.
+    """
+
+    def test_missing_id_properties_derived_from_descriptor(self) -> None:
+        """Both id properties are populated from ``node_id_columns``."""
+        schema = _provider_with_person()
+        _add_knows(schema, with_id_properties=False)
+
+        edge = schema.get_edge_definition("KNOWS", "Person", "Person")
+        assert edge is not None
+        assert edge.source_id_property is not None
+        assert edge.source_id_property.property_name == "person1_id"
+        assert edge.sink_id_property is not None
+        assert edge.sink_id_property.property_name == "person2_id"
+
+    def test_underivable_id_properties_rejected_at_add_edge(self) -> None:
+        """No id properties AND no usable descriptor columns must raise."""
+        schema = _provider_with_person()
+        with pytest.raises(Exception) as exc_info:
+            schema.add_edge(
+                EdgeSchema(
+                    name="KNOWS",
+                    source_node_id="Person",
+                    sink_node_id="Person",
+                ),
+                SQLTableDescriptor(
+                    entity_id="Person@KNOWS@Person",
+                    table_name="dbo.Knows",
+                    node_id_columns=[],
+                ),
+            )
+
+        message = str(exc_info.value).lower()
+        assert "id" in message or "propert" in message, (
+            f"Rejection message should name the missing id properties: "
+            f"{exc_info.value}"
+        )
+
+    def test_rendered_join_keys_exist_in_the_edge_subquery(self) -> None:
+        """Every column named in an ``ON`` clause must be selected somewhere.
+
+        This is the *observable* consequence of the missing validation, and it
+        is asserted without pinning any alias-naming scheme: it simply checks
+        that each identifier used as a join key also appears as an output
+        column of a subquery.
+        """
+        schema = _provider_with_person()
+        _add_knows(schema, with_id_properties=False)
+        sql = _render(schema)
+        print(f"\n=== SQL ===\n{sql}")
+
+        import re
+
+        on_columns = set()
+        for left, right in re.findall(
+            r"ON\s+([\w.]+)\s*=\s*([\w.]+)", sql, flags=re.IGNORECASE
+        ):
+            for ref in (left, right):
+                on_columns.add(ref.split(".")[-1])
+
+        missing = [
+            col
+            for col in on_columns
+            # A join key must be produced by some SELECT item, i.e. appear
+            # as "<expr> AS <col>" somewhere in the query.
+            if not re.search(rf"AS\s+{re.escape(col)}\b", sql)
+        ]
+        assert not missing, (
+            f"These join-key columns are referenced in an ON clause but never "
+            f"produced by any subquery: {missing}. The generated SQL cannot "
+            f"execute.\n{sql}"
+        )
+
+    def test_control_fully_specified_schema_renders_valid_join(self) -> None:
+        """Control: with the id properties set, the same query is fine.
+
+        Confirms the assertion above discriminates the defect rather than
+        rejecting all generated SQL.
+        """
+        schema = _provider_with_person()
+        _add_knows(schema, with_id_properties=True)
+        sql = _render(schema)
+        print(f"\n=== SQL ===\n{sql}")
+
+        import re
+
+        on_columns = set()
+        for left, right in re.findall(
+            r"ON\s+([\w.]+)\s*=\s*([\w.]+)", sql, flags=re.IGNORECASE
+        ):
+            for ref in (left, right):
+                on_columns.add(ref.split(".")[-1])
+
+        missing = [
+            col
+            for col in on_columns
+            if not re.search(rf"AS\s+{re.escape(col)}\b", sql)
+        ]
+        assert not missing, f"Unexpectedly missing: {missing}\n{sql}"

--- a/tests/test_unbounded_vlp_depth_cap.py
+++ b/tests/test_unbounded_vlp_depth_cap.py
@@ -1,0 +1,143 @@
+"""Unbounded variable-length paths are capped at a default maximum depth.
+
+``-[:KNOWS*]->`` and ``-[:KNOWS*2..]->`` have no upper bound in openCypher.
+The transpiler applies a default ceiling of 10 hops instead, so a path of
+length 11 is **silently omitted** from the result -- no warning, no error.
+
+These tests deliberately assert **current behaviour**, not openCypher
+semantics.  The cap is defensible engineering (Spark's recursive-CTE row and
+iteration limits are real, and ``limitations.md`` recommends bounding depth
+explicitly), so removing it is not obviously right.
+
+What *is* wrong is that the cap is **undocumented**:
+``docs_help_dev/limitations.md`` describes recursion limits and recommends
+``max depth <= 10``, but nowhere states that an unbounded ``*`` is silently
+rewritten to ``*1..10``.  A user writing ``*`` believes they asked for a full
+traversal.
+
+These tests exist so the cap is visible and cannot change unnoticed.  The
+documentation gap is reported in ``test-failures-report.md``.
+"""
+
+import re
+
+import pytest
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.schema import (
+    NodeSchema,
+    EdgeSchema,
+    EntityProperty,
+)
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+#: The default ceiling the renderer applies to an unbounded upper bound.
+DEFAULT_MAX_DEPTH = 10
+
+
+def _schema() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[EntityProperty("id", int), EntityProperty("name", str)],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="g.Person", node_id_columns=["id"]),
+    )
+    schema.add_edge(
+        EdgeSchema(
+            name="KNOWS",
+            source_node_id="Person",
+            sink_node_id="Person",
+            source_id_property=EntityProperty("src", int),
+            sink_id_property=EntityProperty("dst", int),
+        ),
+        SQLTableDescriptor(
+            entity_id="Person@KNOWS@Person",
+            table_name="g.Knows",
+            node_id_columns=["src", "dst"],
+        ),
+    )
+    return schema
+
+
+def _render(cypher: str) -> str:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+def _recursion_ceiling(sql: str) -> int | None:
+    """Read the ``p.depth < N`` guard out of the recursive case."""
+    match = re.search(r"depth\s*<\s*(\d+)", sql)
+    return int(match.group(1)) if match else None
+
+
+UNBOUNDED_FORMS = [
+    ("bare_star", "MATCH (a:Person)-[:KNOWS*]->(b:Person) RETURN b.name AS n"),
+    (
+        "open_upper_bound",
+        "MATCH (a:Person)-[:KNOWS*2..]->(b:Person) RETURN b.name AS n",
+    ),
+    (
+        "zero_min_open_upper",
+        "MATCH (a:Person)-[:KNOWS*0..]->(b:Person) RETURN b.name AS n",
+    ),
+]
+
+
+class TestUnboundedVLPDepthCap:
+    """The cap is applied, and it is the value documented here."""
+
+    @pytest.mark.parametrize(
+        "label,cypher", UNBOUNDED_FORMS, ids=[n for n, _ in UNBOUNDED_FORMS]
+    )
+    def test_unbounded_upper_bound_gets_default_ceiling(
+        self, label: str, cypher: str
+    ) -> None:
+        """An open upper bound becomes ``depth < 10`` in the recursive case.
+
+        LOCKS IN CURRENT BEHAVIOUR.  openCypher's ``*`` is unbounded; this
+        asserts the transpiler's deliberate ceiling so a change to it is a
+        visible, reviewed decision rather than a silent one.
+        """
+        sql = _render(cypher)
+        print(f"\n=== SQL ({label}) ===\n{sql}")
+
+        ceiling = _recursion_ceiling(sql)
+        assert ceiling == DEFAULT_MAX_DEPTH, (
+            f"Expected the default ceiling {DEFAULT_MAX_DEPTH} for an "
+            f"unbounded VLP, found {ceiling}.\n{sql}"
+        )
+
+    def test_explicit_bound_is_not_overridden(self) -> None:
+        """Control: an explicit bound below the cap must be respected.
+
+        Guards the tests above -- if the ceiling were applied unconditionally
+        this would also read 10.
+        """
+        sql = _render(
+            "MATCH (a:Person)-[:KNOWS*1..3]->(b:Person) RETURN b.name AS n"
+        )
+        assert _recursion_ceiling(sql) == 3, sql
+
+    def test_explicit_bound_above_cap_is_respected(self) -> None:
+        """An explicit ``*1..15`` must not be silently clamped to 10.
+
+        The user has stated a depth; honouring it is the whole point of
+        making the bound explicit.
+        """
+        sql = _render(
+            "MATCH (a:Person)-[:KNOWS*1..15]->(b:Person) RETURN b.name AS n"
+        )
+        print(f"\n=== SQL ===\n{sql}")
+        assert _recursion_ceiling(sql) == 15, (
+            f"An explicit upper bound of 15 was clamped to "
+            f"{_recursion_ceiling(sql)}.\n{sql}"
+        )

--- a/tests/test_unknown_edge_type_errors.py
+++ b/tests/test_unknown_edge_type_errors.py
@@ -1,0 +1,153 @@
+"""Actionable errors for edge types that do not exist in the schema.
+
+Mirror of the node-label diagnostics: referencing an unknown relationship
+type must fail at BINDING time with the available verbs listed and a
+case-insensitive near-match suggestion — never as a late
+``TranspilerInternalErrorException`` from the enrichment pass ("No enriched
+data for RecursiveTraversalOperator"), which reads as a transpiler bug when
+it is really a schema/config mismatch.
+
+Two failure situations must stay distinct:
+
+- the VERB does not exist anywhere in the schema (a typo) → raise, both in
+  single-type and OR syntax;
+- the verb exists but not for this (source, sink) endpoint combination →
+  silently dropped from the OR list, which is load-bearing for schemas
+  registered with restricted ``edge_combinations``.
+"""
+
+import pytest
+
+from gsql2rsql.common.exceptions import TranspilerBindingException
+from gsql2rsql.graph_context import GraphContext
+
+PROC = {"vlp_rendering_mode": "procedural",
+        "materialization_strategy": "numbered_views"}
+
+
+def _graph() -> GraphContext:
+    graph = GraphContext(
+        nodes_table="nodes",
+        edges_table="edges",
+        node_type_col="node_type",
+        node_id_col="node_id",
+        edge_src_col="src",
+        edge_dst_col="dst",
+        edge_type_col="rel_type",
+        extra_node_attrs={"origin_id": str},
+    )
+    graph.set_types(
+        node_types=["CNPJ_RAIZ", "socio"],
+        edge_types=["OWNS", "PARTICIPA"],
+    )
+    return graph
+
+
+class TestSingleHopUnknownEdgeType:
+    def test_unknown_verb_lists_available(self) -> None:
+        with pytest.raises(TranspilerBindingException) as exc_info:
+            _graph().transpile(
+                "MATCH (a:CNPJ_RAIZ)-[:KNOWS]->(b) RETURN a.origin_id AS x"
+            )
+        message = str(exc_info.value)
+        assert "KNOWS" in message
+        assert "OWNS" in message and "PARTICIPA" in message, (
+            f"error should list available edge types, got: {message}"
+        )
+
+    def test_case_mismatch_suggests_near_match(self) -> None:
+        with pytest.raises(TranspilerBindingException) as exc_info:
+            _graph().transpile(
+                "MATCH (a:CNPJ_RAIZ)-[:owns]->(b) RETURN a.origin_id AS x"
+            )
+        assert "OWNS" in str(exc_info.value)
+
+
+class TestVLPUnknownEdgeType:
+    """VLP used to die late in enrichment as an 'Internal error'."""
+
+    def test_unknown_verb_is_binding_error_not_internal(self) -> None:
+        query = ("MATCH (a:CNPJ_RAIZ {origin_id: 'x'})-[:KNOWS*1..2]->(b) "
+                 "RETURN count(DISTINCT b)")
+        with pytest.raises(TranspilerBindingException) as exc_info:
+            _graph().transpile(query)
+        message = str(exc_info.value)
+        assert "KNOWS" in message
+        assert "OWNS" in message and "PARTICIPA" in message
+
+    def test_case_mismatch_suggests_near_match(self) -> None:
+        query = ("MATCH (a:CNPJ_RAIZ {origin_id: 'x'})-[:owns*1..2]->(b) "
+                 "RETURN count(DISTINCT b)")
+        with pytest.raises(TranspilerBindingException) as exc_info:
+            _graph().transpile(query)
+        assert "OWNS" in str(exc_info.value)
+
+    def test_procedural_mode_same_binding_error(self) -> None:
+        """Binding runs before the renderer fork — mode-independent."""
+        query = ("MATCH (a:CNPJ_RAIZ {origin_id: 'x'})-[:KNOWS*1..2]->(b) "
+                 "RETURN count(DISTINCT b)")
+        with pytest.raises(TranspilerBindingException):
+            _graph().transpile(query, **PROC)
+
+
+class TestOrSyntaxTypoDetection:
+    """A typo inside [:A|B] silently changed semantics before."""
+
+    def test_or_with_unknown_verb_raises(self) -> None:
+        with pytest.raises(TranspilerBindingException) as exc_info:
+            _graph().transpile(
+                "MATCH (a:CNPJ_RAIZ)-[:OWNS|KNOWS]->(b) "
+                "RETURN a.origin_id AS x"
+            )
+        assert "KNOWS" in str(exc_info.value)
+
+    def test_vlp_or_with_unknown_verb_raises(self) -> None:
+        query = ("MATCH (a:CNPJ_RAIZ {origin_id: 'x'})"
+                 "-[:OWNS|KNOWS*1..2]->(b) RETURN count(DISTINCT b)")
+        with pytest.raises(TranspilerBindingException) as exc_info:
+            _graph().transpile(query)
+        assert "KNOWS" in str(exc_info.value)
+
+
+class TestLegitimateCasesUnaffected:
+    def test_known_verbs_still_transpile(self) -> None:
+        graph = _graph()
+        assert graph.transpile(
+            "MATCH (a:CNPJ_RAIZ)-[:OWNS]->(b) RETURN a.origin_id AS x"
+        )
+        assert graph.transpile(
+            "MATCH (a:CNPJ_RAIZ)-[:OWNS|PARTICIPA]->(b) "
+            "RETURN a.origin_id AS x"
+        )
+
+    def test_untyped_edge_still_transpiles(self) -> None:
+        assert _graph().transpile(
+            "MATCH (a:CNPJ_RAIZ)-[]->(b) RETURN a.origin_id AS x"
+        )
+
+    def test_verb_valid_only_for_other_endpoints_is_dropped_not_raised(
+        self,
+    ) -> None:
+        """OR pruning by endpoint combination is load-bearing — keep it.
+
+        ``Y`` exists in the schema but only as A→B; in an A→A pattern the
+        OR list must silently reduce to ``X`` (no typo happened).
+        """
+        graph = GraphContext(
+            nodes_table="nodes",
+            edges_table="edges",
+            node_type_col="node_type",
+            node_id_col="node_id",
+            edge_src_col="src",
+            edge_dst_col="dst",
+            edge_type_col="rel_type",
+            extra_node_attrs={"origin_id": str},
+        )
+        graph.set_types(
+            node_types=["A", "B"],
+            edge_types=["X", "Y"],
+            edge_combinations=[("A", "X", "A"), ("A", "Y", "B")],
+        )
+        assert graph.transpile(
+            "MATCH (a:A)-[:X|Y]->(b:A) RETURN a.origin_id AS v"
+        )

--- a/tests/test_unsupported_aggregations.py
+++ b/tests/test_unsupported_aggregations.py
@@ -1,0 +1,150 @@
+"""Aggregate functions must not silently degrade to their bare operand.
+
+``percentileCont`` and ``percentileDisc`` are declared in
+``AggregationFunction`` (the parser recognises the names) but have no entry in
+``AGGREGATION_TEMPLATES``.  The renderer falls through to emitting the operand,
+so::
+
+    MATCH (p:Person) RETURN percentileCont(p.age, 0.5) AS median
+
+becomes ``SELECT _gsql2rsql_p_age AS median`` -- one row **per person**
+instead of one aggregate value, with no grouping and no warning.
+
+An *unknown* function (``totallyMadeUpFn(x)``) raises correctly, so this is
+specifically the "declared in the enum, absent from the template map" path:
+recognised, then discarded.
+
+The parser also drops the percentile argument: the AST for the query above
+prints as ``PERCENTILE_CONT(p.age)``, with ``0.5`` gone.
+"""
+
+import pytest
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.exceptions import TranspilerException
+from gsql2rsql.common.schema import NodeSchema, EntityProperty
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+
+def _schema() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[
+                EntityProperty("id", int),
+                EntityProperty("name", str),
+                EntityProperty("age", int),
+            ],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="g.Person", node_id_columns=["id"]),
+    )
+    return schema
+
+
+def _render(cypher: str) -> str:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+PERCENTILE_FUNCTIONS = [
+    ("percentileCont", "PERCENTILE_CONT"),
+    ("percentileDisc", "PERCENTILE_DISC"),
+]
+
+
+class TestPercentileAggregates:
+    """Either aggregate properly, or reject -- never pass the operand through."""
+
+    @pytest.mark.parametrize(
+        "cypher_fn,sql_fn",
+        PERCENTILE_FUNCTIONS,
+        ids=[n for n, _ in PERCENTILE_FUNCTIONS],
+    )
+    def test_percentile_is_not_silently_dropped(
+        self, cypher_fn: str, sql_fn: str
+    ) -> None:
+        """The call must survive into the SQL, or the query must be rejected.
+
+        A projection that is neither an aggregate nor a grouping key means the
+        query returns one row per input row -- a silent wrong answer, and the
+        worst possible failure mode.
+        """
+        cypher = f"MATCH (p:Person) RETURN {cypher_fn}(p.age, 0.5) AS median"
+        try:
+            sql = _render(cypher)
+        except TranspilerException:
+            # Acceptable: a clear rejection of an unimplemented aggregate.
+            return
+
+        print(f"\n=== SQL ({cypher_fn}) ===\n{sql}")
+        assert sql_fn in sql.upper(), (
+            f"{cypher_fn}() vanished from the generated SQL, which now "
+            f"returns one row per Person instead of a single aggregate "
+            f"value:\n{sql}"
+        )
+
+    @pytest.mark.parametrize(
+        "cypher_fn,sql_fn",
+        PERCENTILE_FUNCTIONS,
+        ids=[n for n, _ in PERCENTILE_FUNCTIONS],
+    )
+    def test_percentile_argument_survives_parsing(
+        self, cypher_fn: str, sql_fn: str
+    ) -> None:
+        """The percentile itself (``0.5``) must reach the AST.
+
+        Localises the defect: even a correct renderer template could not
+        produce the right SQL if the parser has already discarded the
+        argument.
+        """
+        cypher = f"MATCH (p:Person) RETURN {cypher_fn}(p.age, 0.5) AS median"
+        ast = OpenCypherParser().parse(cypher)
+        rendered = str(ast)
+        print(f"\n=== AST ({cypher_fn}) ===\n{rendered}")
+
+        assert "0.5" in rendered, (
+            f"The percentile argument 0.5 was dropped during parsing; the "
+            f"AST is: {rendered}"
+        )
+
+    def test_unknown_aggregate_still_raises(self) -> None:
+        """Control: a name the parser does not know must be rejected.
+
+        Confirms the pass-through above is specific to enum-declared,
+        template-less aggregates -- not a general failure to validate.
+        """
+        cypher = "MATCH (p:Person) RETURN totallyMadeUpFn(p.age) AS x"
+        with pytest.raises(Exception):
+            sql = _render(cypher)
+            print(f"\n=== SQL (should not exist) ===\n{sql}")
+
+
+class TestSupportedAggregatesStillRender:
+    """Control group: the templated aggregates must keep working."""
+
+    @pytest.mark.parametrize(
+        "cypher_fn,sql_fn",
+        [
+            ("stDevP", "STDDEV_POP"),
+            ("stDev", "STDDEV"),
+            ("first", "FIRST"),
+            ("last", "LAST"),
+            ("min", "MIN"),
+            ("max", "MAX"),
+        ],
+    )
+    def test_templated_aggregate_renders(
+        self, cypher_fn: str, sql_fn: str
+    ) -> None:
+        """These have ``AGGREGATION_TEMPLATES`` entries and must appear."""
+        cypher = f"MATCH (p:Person) RETURN {cypher_fn}(p.age) AS v"
+        sql = _render(cypher)
+        assert sql_fn in sql.upper(), f"{cypher_fn} did not render:\n{sql}"

--- a/tests/test_unsupported_constructs.py
+++ b/tests/test_unsupported_constructs.py
@@ -1,0 +1,219 @@
+"""Unsupported constructs must fail as *library* errors, not internal ones.
+
+Three groups, with deliberately different contracts:
+
+1. **Functions recognised by the parser but absent from the renderer's
+   template map.**  These currently raise ``NotImplementedError``, an
+   internal-invariant error that escapes the public API and names no
+   function.  The tests below assert a ``TranspilerException`` subclass --
+   the correct contract -- so they fail today.  They are *not* ``xfail``:
+   ``docs_help_dev/limitations.md`` does not document these as unsupported,
+   so there is no documented non-support to defer to.
+
+2. **Constructs rejected at parse time.**  These already behave well
+   (``TranspilerSyntaxErrorException`` with a caret-annotated position).
+   Cheap regression lock.
+
+3. **Label predicates** (``WHERE a:Person``), which currently render a
+   non-boolean ``WHERE`` clause.
+
+.. note::
+   Five tests in ``test_where_label_predicates.py`` and
+   ``test_no_label_solution.py`` are ``@pytest.mark.skip``-ed for the
+   label-predicate feature.  This module does not modify them; it adds the
+   error-contract assertion they do not make.
+"""
+
+import pytest
+
+from gsql2rsql import OpenCypherParser, LogicalPlan, SQLRenderer
+from gsql2rsql.common.exceptions import (
+    TranspilerException,
+    TranspilerSyntaxErrorException,
+)
+from gsql2rsql.common.schema import (
+    NodeSchema,
+    EdgeSchema,
+    EntityProperty,
+)
+from gsql2rsql.renderer.schema_provider import (
+    SimpleSQLSchemaProvider,
+    SQLTableDescriptor,
+)
+
+
+def _schema() -> SimpleSQLSchemaProvider:
+    schema = SimpleSQLSchemaProvider()
+    schema.add_node(
+        NodeSchema(
+            name="Person",
+            properties=[
+                EntityProperty("id", int),
+                EntityProperty("name", str),
+                EntityProperty("age", int),
+                EntityProperty("tags", list),
+            ],
+            node_id_property=EntityProperty("id", int),
+        ),
+        SQLTableDescriptor(table_name="g.Person", node_id_columns=["id"]),
+    )
+    schema.add_edge(
+        EdgeSchema(
+            name="KNOWS",
+            source_node_id="Person",
+            sink_node_id="Person",
+            source_id_property=EntityProperty("src", int),
+            sink_id_property=EntityProperty("dst", int),
+        ),
+        SQLTableDescriptor(
+            entity_id="Person@KNOWS@Person",
+            table_name="g.Knows",
+            node_id_columns=["src", "dst"],
+        ),
+    )
+    return schema
+
+
+def _transpile(cypher: str) -> str:
+    schema = _schema()
+    ast = OpenCypherParser().parse(cypher)
+    plan = LogicalPlan.process_query_tree(ast, schema)
+    plan.resolve(original_query=cypher)
+    return SQLRenderer(db_schema_provider=schema).render_plan(plan)
+
+
+# ---------------------------------------------------------------------------
+# Group 1: recognised by the parser, no renderer template
+# ---------------------------------------------------------------------------
+UNTEMPLATED_FUNCTIONS = [
+    ("split", "MATCH (p:Person) RETURN split(p.name, ' ') AS parts"),
+    ("substring", "MATCH (p:Person) RETURN substring(p.name, 0, 3) AS s"),
+    ("replace", "MATCH (p:Person) RETURN replace(p.name, 'a', 'b') AS r"),
+    ("reverse", "MATCH (p:Person) RETURN reverse(p.name) AS r"),
+    ("head", "MATCH (p:Person) RETURN head(p.tags) AS h"),
+    ("tail", "MATCH (p:Person) RETURN tail(p.tags) AS t"),
+    ("keys", "MATCH (p:Person) RETURN keys(p) AS k"),
+    ("labels", "MATCH (p:Person) RETURN labels(p) AS l"),
+    ("id", "MATCH (p:Person) RETURN id(p) AS i"),
+    ("properties", "MATCH (p:Person) RETURN properties(p) AS props"),
+]
+
+
+class TestUntemplatedFunctionsRaiseLibraryError:
+    """``NotImplementedError`` must not escape the public API."""
+
+    @pytest.mark.parametrize(
+        "fn_name,cypher",
+        UNTEMPLATED_FUNCTIONS,
+        ids=[n for n, _ in UNTEMPLATED_FUNCTIONS],
+    )
+    def test_raises_transpiler_exception_naming_the_function(
+        self, fn_name: str, cypher: str
+    ) -> None:
+        """Either render it, or reject it with an actionable library error.
+
+        ``NotImplementedError: _render_function: unsupported function
+        <Function.INVALID: 1>`` fails on both counts: it is not a
+        ``TranspilerException``, and it names ``INVALID`` rather than the
+        function the user actually wrote.
+        """
+        try:
+            sql = _transpile(cypher)
+        except TranspilerException as exc:
+            # Correct contract: a library error that names the construct.
+            assert fn_name.lower() in str(exc).lower(), (
+                f"Error does not name '{fn_name}', so the user cannot tell "
+                f"which function is unsupported: {exc}"
+            )
+            return
+        except NotImplementedError as exc:
+            pytest.fail(
+                f"NotImplementedError escaped the public API for "
+                f"'{fn_name}()': {exc}. This is an internal-invariant error; "
+                f"users should see a TranspilerNotSupportedException naming "
+                f"the function."
+            )
+        else:
+            # Rendering is also acceptable -- the function is supported.
+            assert fn_name.lower() in sql.lower() or sql, sql
+
+
+# ---------------------------------------------------------------------------
+# Group 2: rejected at parse time -- already good, lock it in
+# ---------------------------------------------------------------------------
+SYNTAX_REJECTED = [
+    (
+        "shortestPath",
+        "MATCH p = shortestPath((a:Person)-[:KNOWS*1..5]->(b:Person)) RETURN p",
+    ),
+    (
+        "allShortestPaths",
+        "MATCH p = allShortestPaths((a:Person)-[:KNOWS*1..5]->(b:Person)) "
+        "RETURN p",
+    ),
+    ("map_projection", "MATCH (p:Person) RETURN p{.id, .name} AS m"),
+    (
+        "call_subquery",
+        "MATCH (p:Person) CALL { WITH p MATCH (p)-[:KNOWS]->(f) "
+        "RETURN count(f) AS c } RETURN p.name, c",
+    ),
+    (
+        "count_subquery",
+        "MATCH (p:Person) RETURN COUNT { (p)-[:KNOWS]->() } AS degree",
+    ),
+    ("regex_match", "MATCH (p:Person) WHERE p.name =~ 'A.*' RETURN p.name"),
+]
+
+
+class TestSyntaxLevelRejections:
+    """Constructs the grammar does not accept fail cleanly at parse time."""
+
+    @pytest.mark.parametrize(
+        "label,cypher", SYNTAX_REJECTED, ids=[n for n, _ in SYNTAX_REJECTED]
+    )
+    def test_raises_syntax_error_with_position(
+        self, label: str, cypher: str
+    ) -> None:
+        """A syntax error, not a crash deep in the pipeline."""
+        with pytest.raises(TranspilerSyntaxErrorException) as exc_info:
+            _transpile(cypher)
+
+        message = str(exc_info.value)
+        assert "line" in message.lower(), (
+            f"Syntax error for {label} gives no position: {message}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group 3: label predicates render a non-boolean WHERE
+# ---------------------------------------------------------------------------
+class TestLabelPredicateErrorContract:
+    """``WHERE a:Person`` must fail loudly rather than emit ``WHERE <id>``."""
+
+    def test_label_predicate_raises_instead_of_bare_id_column(self) -> None:
+        """Today this renders ``WHERE _gsql2rsql_a_id`` -- not a boolean.
+
+        Databricks rejects a non-boolean ``WHERE`` operand, so the user gets a
+        confusing SQL error instead of a transpiler error naming the
+        unsupported construct.
+        """
+        cypher = (
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) WHERE a:Person "
+            "RETURN a.name AS name"
+        )
+        with pytest.raises(TranspilerException):
+            sql = _transpile(cypher)
+            print(f"\n=== SQL (should not have been produced) ===\n{sql}")
+
+    def test_disjunctive_label_predicate_raises(self) -> None:
+        """``WHERE a:Person OR a:Company`` loses the label information entirely.
+
+        Both branches currently render to the *same* bare id column, so even
+        the distinction between the two labels is gone.
+        """
+        cypher = (
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) "
+            "WHERE a:Person OR a:Person RETURN a.name AS name"
+        )
+        with pytest.raises(TranspilerException):
+            _transpile(cypher)

--- a/tests/utils/spark_session.py
+++ b/tests/utils/spark_session.py
@@ -1,0 +1,95 @@
+"""Shared SparkSession infrastructure for PySpark tests.
+
+A single JVM/SparkContext is created lazily per process and reused by all
+test modules.  Each module gets an isolated ``SparkSession`` via
+``newSession()`` (own temp-view catalog, own runtime SQL conf), preserving
+module-level isolation without paying ~30 SparkContext restarts per run.
+
+The base session is intentionally never stopped: ``spark.stop()`` would
+kill the shared SparkContext for every subsequent module.  Managed tables
+and databases share the metastore across child sessions; the autouse
+fixture in tests/conftest.py resets that state between modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+_BASE: "SparkSession | None" = None
+_HAS_SCRIPTING: bool | None = None
+
+
+def _is_live(session: "SparkSession") -> bool:
+    """True if the session's SparkContext has not been stopped."""
+    try:
+        return not session.sparkContext._jsc.sc().isStopped()
+    except Exception:
+        # Any failure probing the JVM means the context is unusable.
+        return False
+
+
+def get_base_spark() -> "SparkSession":
+    """Return the process-wide base SparkSession, creating it on first use.
+
+    Several older modules in ``tests/pyspark_tests`` still call
+    ``spark.stop()`` in a fixture teardown (see the module docstring).  That
+    kills the shared SparkContext, so a cached ``_BASE`` handed out afterwards
+    raises ``IllegalStateException: Cannot call methods on a stopped
+    SparkContext`` for every later module.  Rebuild rather than hand back a
+    dead session -- correctness of later modules must not depend on
+    alphabetical test ordering.
+    """
+    global _BASE
+    if _BASE is not None and _is_live(_BASE):
+        return _BASE
+    _BASE = None
+    from pyspark.sql import SparkSession
+
+    _BASE = (
+        SparkSession.builder
+        .appName("gsql2rsql_tests")
+        .master("local[2]")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.sql.scripting.enabled", "true")
+        .config("spark.ui.enabled", "false")
+        .config("spark.driver.memory", "2g")
+        .getOrCreate()
+    )
+    _BASE.sparkContext.setLogLevel("ERROR")
+    return _BASE
+
+
+def base_spark_or_none() -> "SparkSession | None":
+    """Return the base session only if one was already started."""
+    return _BASE
+
+
+def new_test_session(conf: dict[str, str] | None = None) -> "SparkSession":
+    """Isolated child session sharing the base SparkContext.
+
+    Temp views and runtime SQL confs set on the returned session do not
+    leak to other sessions.
+    """
+    session = get_base_spark().newSession()
+    for key, value in (conf or {}).items():
+        session.conf.set(key, value)
+    return session
+
+
+def has_pyspark_scripting() -> bool:
+    """Probe SQL scripting support (PySpark >= 4.2) using the shared base.
+
+    Import-time probes must not create-and-stop their own session: a
+    ``stop()`` there would kill the shared context for later modules.
+    """
+    global _HAS_SCRIPTING
+    if _HAS_SCRIPTING is None:
+        try:
+            get_base_spark().sql("BEGIN DECLARE x INT DEFAULT 1; END")
+            _HAS_SCRIPTING = True
+        except Exception:
+            _HAS_SCRIPTING = False
+    return _HAS_SCRIPTING


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature (triggers minor version bump)
- [ ] `fix`: Bug fix (triggers patch version bump)
- [ ] `perf`: Performance improvement (triggers patch version bump)
- [ ] `docs`: Documentation only changes
- [ ] `style`: Code style changes (formatting, missing semi colons, etc)
- [ ] `refactor`: Code refactoring without functionality changes
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Changes to build process or auxiliary tools
- [ ] `ci`: Changes to CI configuration files and scripts

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes -->

- [ ] Unit tests pass (`make test-no-pyspark`)
- [ ] PySpark tests pass (`make test-pyspark`)
- [ ] Linting passes (`make lint`)
- [ ] Type checking passes (`make typecheck`)

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related Issues

<!-- Link any related issues here. Use "Closes #123" to auto-close issues when merged -->

Closes #
